### PR TITLE
Add Storybook setup with Tailwind support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /build/
 
 .env*
+
+*storybook.log
+storybook-static

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,21 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+import { mergeConfig } from 'vite';
+
+const config: StorybookConfig = {
+    stories: [
+        '../stories/**/*.mdx',
+        '../stories/**/*.stories.@(js|jsx|ts|tsx)',
+    ],
+    addons: ['@storybook/addon-essentials'],
+    framework: {
+        name: '@storybook/react-vite',
+        options: {},
+    },
+    async viteFinal(config) {
+        const { default: viteConfig } = await import(
+            '../vite.storybook.config'
+        );
+        return mergeConfig(config, viteConfig);
+    },
+};
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import '../app/app.css';
+import type { Preview } from '@storybook/react-vite';
+
+const preview: Preview = {
+    parameters: {
+        controls: {
+            matchers: {
+                color: /(background|color)$/i,
+                date: /Date$/i,
+            },
+        },
+    },
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
         "dev": "react-router dev",
         "start": "react-router-serve ./build/server/index.js",
         "typecheck": "react-router typegen && tsc",
-        "format": "pnpm exec prettier . --write"
+        "format": "pnpm exec prettier . --write",
+        "storybook": "storybook dev -p 6006",
+        "build-storybook": "storybook build"
     },
     "dependencies": {
         "@conform-to/react": "^1.2.2",
@@ -27,6 +29,7 @@
     },
     "devDependencies": {
         "@react-router/dev": "7.1.5",
+        "@storybook/react-vite": "^9.0.12",
         "@tailwindcss/vite": "4.0.0",
         "@types/node": "20",
         "@types/react": "19.0.1",
@@ -35,10 +38,13 @@
         "postcss-nesting": "^13.0.2",
         "prettier": "3.5.1",
         "react-router-devtools": "1.1.0",
+        "storybook": "^9.0.12",
         "tailwindcss": "4.0.0",
         "typescript": "5.7.2",
         "vite": "5.4.11",
-        "vite-tsconfig-paths": "5.1.4"
+        "vite-tsconfig-paths": "5.1.4",
+        "@storybook/addon-essentials": "^9.0.12",
+        "@vitejs/plugin-react": "^4.2.1"
     },
     "packageManager": "pnpm@10.2.1"
 }

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '../app/components/button';
+import '../app/components/button.css';
+
+const meta: Meta<typeof Button> = {
+    title: 'Components/Button',
+    component: Button,
+    argTypes: {
+        variant: {
+            control: 'select',
+            options: ['primary', 'secondary', 'tertiary'],
+        },
+        size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+    args: { children: 'Primary', variant: 'primary', size: 'md' },
+};
+
+export const Secondary: Story = {
+    args: { children: 'Secondary', variant: 'secondary', size: 'md' },
+};
+
+export const Tertiary: Story = {
+    args: { children: 'Tertiary', variant: 'tertiary', size: 'md' },
+};

--- a/vite.storybook.config.ts
+++ b/vite.storybook.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+    plugins: [react(), tailwindcss(), tsconfigPaths()],
+});


### PR DESCRIPTION
## Summary
- configure Storybook using `@storybook/react-vite`
- add dedicated `vite.storybook.config.ts`
- include Tailwind styles in Storybook preview
- provide example Button story using project component
- ignore Storybook build artifacts

## Testing
- `pnpm exec prettier . --check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b9ebcab48333a829053c182bb389