### PR TITLE
ISSUE-24: Home Page Travel Timeline View Part 2

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -56,6 +56,9 @@ h6 {
     @apply hidden sm:inline;
 }
 
+.direction-ltr {
+    direction: ltr;
+}
 .direction-rtl {
     direction: rtl;
 }

--- a/app/app.css
+++ b/app/app.css
@@ -23,6 +23,10 @@
 
 @import './font.css';
 
+* {
+    user-select: none;
+}
+
 html,
 body {
     @apply bg-white dark:bg-gray-900 text-gray-900 dark:text-white;

--- a/app/app.css
+++ b/app/app.css
@@ -43,7 +43,8 @@ h6 {
     @apply text-balance;
 }
 
-p, span {
+p,
+span {
     @apply text-balance;
 }
 

--- a/app/app.css
+++ b/app/app.css
@@ -40,6 +40,11 @@ h4,
 h5,
 h6 {
     font-family: var(--font-header);
+    @apply text-balance;
+}
+
+p, span {
+    @apply text-balance;
 }
 
 .mobile-only-block {

--- a/app/containers/footer/footer.tsx
+++ b/app/containers/footer/footer.tsx
@@ -32,7 +32,7 @@ export const Footer: FC<{ className?: string }> = ({ className }) => {
                 />{' '}
                 <span className="text-xs sm:text-sm">All Rights Reserved</span>
             </p>
-            <p className="text-xs text-balance opacity-80">
+            <p className="text-xs opacity-80">
                 No part of this website — including text, images, or any other
                 content — may be copied, reproduced, distributed, or used in any
                 manner without written permission from the copyright owner.{' '}

--- a/app/containers/index/travel-highlight.tsx
+++ b/app/containers/index/travel-highlight.tsx
@@ -87,7 +87,7 @@ export const TravelHighlight: FC<{ className?: string }> = ({ className }) => {
                         {BannerConfig[index].title}
                     </h1>
 
-                    <p className="mt-1.5 text-xs xs:text-sm px-4 text-balance text-center text-white">
+                    <p className="mt-1.5 text-xs xs:text-sm px-4 text-center text-white">
                         {BannerConfig[index].description}
                     </p>
                 </div>

--- a/app/containers/index/travel-stats/travel-stats.tsx
+++ b/app/containers/index/travel-stats/travel-stats.tsx
@@ -116,7 +116,7 @@ export const TravelStats: FC<TravelStatsProps> = ({ className }) => {
                             <p className='font-header font-bold text-sm'>
                                 {name}
                             </p>
-                            <p className='text-xs text-white/70 text-balance'>
+                            <p className='text-xs text-white/70'>
                                 {fullname}
                             </p>
                         </li>

--- a/app/containers/index/travel-stats/travelled-countries-flag-list.desktop.tsx
+++ b/app/containers/index/travel-stats/travelled-countries-flag-list.desktop.tsx
@@ -1,37 +1,7 @@
 import type { FC } from 'react';
-import { Tooltip } from '~/components/tooltip';
 import type { CountryInfo } from '~/data-access/country';
-import { CountryFlagIcon } from '~/icons/country/country';
+import { CountryFlagChip } from '~/ui/country-flag-chip';
 import { trim } from '~/utils/trim';
-
-interface CountryFlagListItemProps
-    extends Pick<CountryInfo, 'countryCode' | 'name'> {}
-
-export const CountryFlagListItem: FC<CountryFlagListItemProps> = ({
-    countryCode,
-    name,
-}) => (
-    <li key={countryCode} className="text-gray-400 hover:text-gray-900">
-        <Tooltip
-            key={countryCode}
-            triggerButtonProps={{
-                className: '!px-0.5 !py-0.5',
-                variant: 'tertiary',
-            }}
-            tooltip={<p className="text-sm text-balance text-center">{name}</p>}
-        >
-            <div className="flex flex-col">
-                <CountryFlagIcon
-                    countryCode={countryCode}
-                    className="rounded size-5 md:size-7"
-                />
-                <p className="text-xs text-center uppercase font-header mt-0.5">
-                    {countryCode}
-                </p>
-            </div>
-        </Tooltip>
-    </li>
-);
 
 interface CountryFlagListProps {
     countries: Array<Pick<CountryInfo, 'countryCode' | 'name'>>;
@@ -51,8 +21,14 @@ export const CountryFlagList: FC<CountryFlagListProps> = ({
         ${className}
     `}
     >
-        {countries.map((info) => (
-            <CountryFlagListItem key={info.countryCode} {...info} />
+        {countries.map(({ countryCode, name }) => (
+            <li key={countryCode} className="text-gray-400 hover:text-gray-900">
+                <CountryFlagChip
+                    countryCode={countryCode}
+                    name={name}
+                    countryFlagIconClassName="size-5 md:size-7"
+                />
+            </li>
         ))}
     </ul>
 );

--- a/app/containers/index/trip-timeline/attractions-carousel.css
+++ b/app/containers/index/trip-timeline/attractions-carousel.css
@@ -1,7 +1,7 @@
 @reference 'tailwindcss';
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
-.image-carousel__hidden-btn {
+.attractions-carousel__hidden-btn {
     @apply absolute w-[50%] h-[75%] z-3 top-0;
 
     & + button {
@@ -18,9 +18,9 @@
     }
 }
 
-.image-carousel__hidden-btn:hover + button,
-.image-carousel__hidden-btn + button:focus,
-.image-carousel__hidden-btn + button:hover, {
+.attractions-carousel__hidden-btn:hover + button,
+.attractions-carousel__hidden-btn + button:focus,
+.attractions-carousel__hidden-btn + button:hover, {
     & > span {
         @apply
             bg-blue-500 dark:bg-yellow-300
@@ -28,7 +28,7 @@
     }
 }
 
-.image-carousel__hidden-btn + button:disabled > span {
+.attractions-carousel__hidden-btn + button:disabled > span {
     @apply text-gray-400 bg-gray-200 
         dark:text-gray-400 dark:bg-gray-700;
 }

--- a/app/containers/index/trip-timeline/attractions-carousel.css
+++ b/app/containers/index/trip-timeline/attractions-carousel.css
@@ -20,10 +20,9 @@
 
 .attractions-carousel__hidden-btn:hover + button,
 .attractions-carousel__hidden-btn + button:focus,
-.attractions-carousel__hidden-btn + button:hover, {
+.attractions-carousel__hidden-btn + button:hover {
     & > span {
-        @apply
-            bg-blue-500 dark:bg-yellow-300
+        @apply bg-blue-500 dark:bg-yellow-300
             text-white dark:text-gray-800;
     }
 }

--- a/app/containers/index/trip-timeline/attractions-carousel.tsx
+++ b/app/containers/index/trip-timeline/attractions-carousel.tsx
@@ -5,11 +5,11 @@ import { ChevronRightOutlineIcon } from "~/icons/outline/chevron-right";
 import { MapPinOutlineIcon } from "~/icons/outline/map-pin";
 import { trim } from "~/utils/trim";
 import { useIsMouseEntering } from "~/hooks/use-is-mouse-entering";
-import './image-carousel.css';
+import './attractions-carousel.css';
 
-export interface ImageCarouselProps {
+export interface AttractionsCarouselProps {
     className?: string;
-    images: Array<{
+    attractions: Array<{
         url: string;
         description?: string;
         location?: {
@@ -23,41 +23,41 @@ export interface ImageCarouselProps {
 
 let timeoutSignature: ReturnType<typeof setTimeout> | undefined;
 
-export const ImageCarousel: FC<ImageCarouselProps> = ({
+export const AttractionsCarousel: FC<AttractionsCarouselProps> = ({
     className,
-    images,
+    attractions,
     autoplay,
     autoplayDuration = 5000
 }) => {
-    const [focusImgIndex, setFocusImgIndex] = useState(0);
+    const [focusAttractionIndex, setFocusAttractionIndex] = useState(0);
     const containerRef = useRef<HTMLDivElement>(null);
     const isEnteringImageCarousel = useIsMouseEntering(containerRef);
 
     const {
         description,
         location
-    } = images[focusImgIndex];
+    } = attractions[focusAttractionIndex];
 
-    const translation = `translateX(calc(-${100 * focusImgIndex}%))`;
+    const translation = `translateX(calc(-${100 * focusAttractionIndex}%))`;
 
     const switchImageTo = (direction: 'prev' | 'next') => {
-        if (direction === 'prev' && focusImgIndex !== 0) {
-            setFocusImgIndex(state => state - 1);
-        } else if (direction === 'next' && focusImgIndex !== images.length - 1) {
-            setFocusImgIndex(state => state + 1);
+        if (direction === 'prev' && focusAttractionIndex !== 0) {
+            setFocusAttractionIndex(state => state - 1);
+        } else if (direction === 'next' && focusAttractionIndex !== attractions.length - 1) {
+            setFocusAttractionIndex(state => state + 1);
         } else {
             console.warn(`Unable to switch to "${direction}" image`);
         }
     };
 
-    const disablePrevBtn = focusImgIndex === 0;
-    const disableNextBtn = focusImgIndex === images.length - 1;
+    const disablePrevBtn = focusAttractionIndex === 0;
+    const disableNextBtn = focusAttractionIndex === attractions.length - 1;
 
     const scheduleAutoplay = () => setTimeout(() => {
-        if (focusImgIndex === images.length - 1) {
-            setFocusImgIndex(0);
+        if (focusAttractionIndex === attractions.length - 1) {
+            setFocusAttractionIndex(0);
         } else {
-            setFocusImgIndex(i => i + 1);
+            setFocusAttractionIndex(i => i + 1);
         }
     }, autoplayDuration);
 
@@ -86,7 +86,7 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({
                 <div className='inline-flex flex-nowrap w-full h-full direction-ltr transition-transform duration-300 ease-in-out'
                     style={{ transform: translation }}
                 >
-                    {images.map(({ url }, i) => (
+                    {attractions.map(({ url }, i) => (
                         <div
                             key={i}
                             style={{ backgroundImage: `url(${url})` }}
@@ -108,11 +108,11 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({
                     flex items-center justify-center gap-x-1.5
                     direction-ltr
                 `}>
-                    {images.map((_, i) => (
+                    {attractions.map((_, i) => (
                         <span key={i} className={trim`
                             inline-block rounded-md
                             transition-all duration-250 ease-in-out
-                            ${i === focusImgIndex
+                            ${i === focusAttractionIndex
                                 ? 'bg-blue-500 dark:bg-yellow-300 w-2.5 h-2.5'
                                 : 'bg-blue-500/60 dark:bg-yellow-300/60 w-1.5 h-1.5'
                             }
@@ -146,7 +146,7 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({
                 role='button'
                 aria-hidden='true'
                 className={trim`
-                    image-carousel__hidden-btn
+                    attractions-carousel__hidden-btn
                     direction-ltr left-0
                 `}
                 onClick={() => !disablePrevBtn && switchImageTo('prev')}
@@ -167,7 +167,7 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({
                 role='button'
                 aria-hidden='true'
                 className={trim`
-                    image-carousel__hidden-btn
+                    attractions-carousel__hidden-btn
                     direction-ltr right-0
                 `}
                 onClick={() => !disableNextBtn && switchImageTo('next')}

--- a/app/containers/index/trip-timeline/attractions-carousel.tsx
+++ b/app/containers/index/trip-timeline/attractions-carousel.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState, type FC } from "react";
-import { CountryFlagIcon } from "~/icons/country/country";
-import { ChevronLeftOutlineIcon } from "~/icons/outline/chevron-left";
-import { ChevronRightOutlineIcon } from "~/icons/outline/chevron-right";
-import { MapPinOutlineIcon } from "~/icons/outline/map-pin";
-import { trim } from "~/utils/trim";
-import { useIsMouseEntering } from "~/hooks/use-is-mouse-entering";
-import { Button } from "~/components/button";
+import { useEffect, useRef, useState, type FC } from 'react';
+import { CountryFlagIcon } from '~/icons/country/country';
+import { ChevronLeftOutlineIcon } from '~/icons/outline/chevron-left';
+import { ChevronRightOutlineIcon } from '~/icons/outline/chevron-right';
+import { MapPinOutlineIcon } from '~/icons/outline/map-pin';
+import { trim } from '~/utils/trim';
+import { useIsMouseEntering } from '~/hooks/use-is-mouse-entering';
+import { Button } from '~/components/button';
 import './attractions-carousel.css';
 
 export interface AttractionsCarouselProps {
@@ -29,24 +29,24 @@ export const AttractionsCarousel: FC<AttractionsCarouselProps> = ({
     className,
     attractions,
     autoplay,
-    autoplayDuration = 5000
+    autoplayDuration = 5000,
 }) => {
     const [focusAttractionIndex, setFocusAttractionIndex] = useState(0);
     const containerRef = useRef<HTMLDivElement>(null);
     const isEnteringImageCarousel = useIsMouseEntering(containerRef);
 
-    const {
-        description,
-        location
-    } = attractions[focusAttractionIndex];
+    const { description, location } = attractions[focusAttractionIndex];
 
     const translation = `translateX(calc(-${100 * focusAttractionIndex}%))`;
 
     const switchImageTo = (direction: 'prev' | 'next') => {
         if (direction === 'prev' && focusAttractionIndex !== 0) {
-            setFocusAttractionIndex(state => state - 1);
-        } else if (direction === 'next' && focusAttractionIndex !== attractions.length - 1) {
-            setFocusAttractionIndex(state => state + 1);
+            setFocusAttractionIndex((state) => state - 1);
+        } else if (
+            direction === 'next' &&
+            focusAttractionIndex !== attractions.length - 1
+        ) {
+            setFocusAttractionIndex((state) => state + 1);
         } else {
             console.warn(`Unable to switch to "${direction}" image`);
         }
@@ -55,17 +55,18 @@ export const AttractionsCarousel: FC<AttractionsCarouselProps> = ({
     const disablePrevBtn = focusAttractionIndex === 0;
     const disableNextBtn = focusAttractionIndex === attractions.length - 1;
 
-    const scheduleAutoplay = () => setTimeout(() => {
-        if (focusAttractionIndex === attractions.length - 1) {
-            setFocusAttractionIndex(0);
-        } else {
-            setFocusAttractionIndex(i => i + 1);
-        }
-    }, autoplayDuration);
+    const scheduleAutoplay = () =>
+        setTimeout(() => {
+            if (focusAttractionIndex === attractions.length - 1) {
+                setFocusAttractionIndex(0);
+            } else {
+                setFocusAttractionIndex((i) => i + 1);
+            }
+        }, autoplayDuration);
 
     /**
      *  We autoplay the image carousel only when mouse is NOT focusing
-     *  the image carousel component but is marked as autoplay: true 
+     *  the image carousel component but is marked as autoplay: true
      */
     const shouldAutoplay = autoplay && !isEnteringImageCarousel;
     useEffect(() => {
@@ -77,123 +78,148 @@ export const AttractionsCarousel: FC<AttractionsCarouselProps> = ({
 
         return () => {
             clearTimeout(timeoutSignature);
-        }
+        };
     }, [shouldAutoplay, autoplayDuration, scheduleAutoplay]);
 
     return (
-        <div ref={containerRef} className={`relative w-full h-full px-[1.5rem] ${className}`}>
-            <div
-                className='relative w-full h-[75%] overflow-hidden text-[0px]'
-            >
-                <div className='inline-flex flex-nowrap w-full h-full direction-ltr transition-transform duration-300 ease-in-out'
+        <div
+            ref={containerRef}
+            className={`relative w-full h-full px-[1.5rem] ${className}`}
+        >
+            <div className="relative w-full h-[75%] overflow-hidden text-[0px]">
+                <div
+                    className="inline-flex flex-nowrap w-full h-full direction-ltr transition-transform duration-300 ease-in-out"
                     style={{ transform: translation }}
                 >
                     {attractions.map(({ url }, i) => (
                         <div
                             key={i}
                             style={{ backgroundImage: `url(${url})` }}
-                            className='flex-[0_0_auto] w-full h-full bg-center bg-cover bg-no-repeat z-1'
+                            className="flex-[0_0_auto] w-full h-full bg-center bg-cover bg-no-repeat z-1"
                         />
                     ))}
                 </div>
 
-                <div className={trim`
+                <div
+                    className={trim`
                     absolute w-full h-[50px]
                     left-0 bottom-0 z-1
                     bg-gradient-to-t from-white dark:from-gray-900
                     to-transparent
-                `} />
+                `}
+                />
 
-                <div className={trim`
+                <div
+                    className={trim`
                     w-full h-[35px]
                     absolute bottom-0 left-0 z-2
                     flex items-center justify-center gap-x-1.5
                     direction-ltr
-                `}>
+                `}
+                >
                     {attractions.map((_, i) => (
-                        <span key={i} className={trim`
+                        <span
+                            key={i}
+                            className={trim`
                             inline-block rounded-md
                             transition-all duration-250 ease-in-out
-                            ${i === focusAttractionIndex
-                                ? 'bg-blue-500 dark:bg-yellow-300 w-2.5 h-2.5'
-                                : 'bg-blue-500/60 dark:bg-yellow-300/60 w-1.5 h-1.5'
+                            ${
+                                i === focusAttractionIndex
+                                    ? 'bg-blue-500 dark:bg-yellow-300 w-2.5 h-2.5'
+                                    : 'bg-blue-500/60 dark:bg-yellow-300/60 w-1.5 h-1.5'
                             }
-                        `} />
+                        `}
+                        />
                     ))}
                 </div>
             </div>
 
-            <div className='w-full px-2 py-3 direction-ltr'>
+            <div className="w-full px-2 py-3 direction-ltr">
                 {location ? (
-                    <p className='flex flex-row gap-x-1 text-xs items-center'>
-                        <CountryFlagIcon className='rounded mr-1' countryCode={location.countryCode} size='sm' />
-                        <span>{location.name}</span>                        
+                    <p className="flex flex-row gap-x-1 text-xs items-center">
+                        <CountryFlagIcon
+                            className="rounded mr-1"
+                            countryCode={location.countryCode}
+                            size="sm"
+                        />
+                        <span>{location.name}</span>
                     </p>
                 ) : (
-                    <p className='flex flex-row gap-x-1 text-xs items-center text-gray-500 dark:text-gray-400'>
-                        <MapPinOutlineIcon size='sm' />
+                    <p className="flex flex-row gap-x-1 text-xs items-center text-gray-500 dark:text-gray-400">
+                        <MapPinOutlineIcon size="sm" />
                         <span>Unknown Location</span>
                     </p>
                 )}
-                <p className={trim`
+                <p
+                    className={trim`
                     text-sm tracking-wide font-light my-4 line-clamp-3
                     ${description ? '' : 'text-xs text-gray-500 dark:text-gray-400'}
-                `}>
+                `}
+                >
                     {description ?? 'No Description Provided'}
                 </p>
 
                 <div>
                     <Button
-                        size='xs'
-                        variant='secondary'
-                        className='!border-1'
-                        aria-label={`View the details of ${attractions[focusAttractionIndex].name}`}>
-                            View Details
+                        size="xs"
+                        variant="secondary"
+                        className="!border-1"
+                        aria-label={`View the details of ${attractions[focusAttractionIndex].name}`}
+                    >
+                        View Details
                     </Button>
                 </div>
             </div>
 
             {/* This is a hidden button to let image left side entire area to be clickable */}
             <div
-                role='button'
-                aria-hidden='true'
+                role="button"
+                aria-hidden="true"
                 className={trim`
                     attractions-carousel__hidden-btn
                     direction-ltr left-0
                 `}
                 onClick={() => !disablePrevBtn && switchImageTo('prev')}
             />
-            <button className={trim`
+            <button
+                className={trim`
                 direction-ltr text-left left-0
             `}
                 disabled={disablePrevBtn}
                 onClick={() => switchImageTo('prev')}
             >
-                <span className='rounded-l-sm'>
-                    <ChevronLeftOutlineIcon size='sm' className='inline-block' />
+                <span className="rounded-l-sm">
+                    <ChevronLeftOutlineIcon
+                        size="sm"
+                        className="inline-block"
+                    />
                 </span>
             </button>
 
             {/* This is a hidden button to let image right side entire area to be clickable */}
             <div
-                role='button'
-                aria-hidden='true'
+                role="button"
+                aria-hidden="true"
                 className={trim`
                     attractions-carousel__hidden-btn
                     direction-ltr right-0
                 `}
                 onClick={() => !disableNextBtn && switchImageTo('next')}
             />
-            <button className={trim`
+            <button
+                className={trim`
                 direction-ltr text-right right-0
             `}
                 disabled={disableNextBtn}
                 onClick={() => switchImageTo('next')}
             >
-                <span className='rounded-r-sm'>
-                    <ChevronRightOutlineIcon size='sm' className='inline-block' />
+                <span className="rounded-r-sm">
+                    <ChevronRightOutlineIcon
+                        size="sm"
+                        className="inline-block"
+                    />
                 </span>
             </button>
         </div>
-    )
+    );
 };

--- a/app/containers/index/trip-timeline/attractions-carousel.tsx
+++ b/app/containers/index/trip-timeline/attractions-carousel.tsx
@@ -5,6 +5,7 @@ import { ChevronRightOutlineIcon } from "~/icons/outline/chevron-right";
 import { MapPinOutlineIcon } from "~/icons/outline/map-pin";
 import { trim } from "~/utils/trim";
 import { useIsMouseEntering } from "~/hooks/use-is-mouse-entering";
+import { Button } from "~/components/button";
 import './attractions-carousel.css';
 
 export interface AttractionsCarouselProps {
@@ -12,6 +13,7 @@ export interface AttractionsCarouselProps {
     attractions: Array<{
         url: string;
         description?: string;
+        name: string;
         location?: {
             name: string;
             countryCode: string;
@@ -67,13 +69,13 @@ export const AttractionsCarousel: FC<AttractionsCarouselProps> = ({
      */
     const shouldAutoplay = autoplay && !isEnteringImageCarousel;
     useEffect(() => {
-        clearTimeout(timeoutSignature);
-
         if (shouldAutoplay) {
-            console.log('scheduling')
             timeoutSignature = scheduleAutoplay();
         } else {
-            console.log('cleared')
+            clearTimeout(timeoutSignature);
+        }
+
+        return () => {
             clearTimeout(timeoutSignature);
         }
     }, [shouldAutoplay, autoplayDuration, scheduleAutoplay]);
@@ -134,11 +136,21 @@ export const AttractionsCarousel: FC<AttractionsCarouselProps> = ({
                     </p>
                 )}
                 <p className={trim`
-                    text-sm tracking-wide text-balance font-light my-4 line-clamp-3
+                    text-sm tracking-wide font-light my-4 line-clamp-3
                     ${description ? '' : 'text-xs text-gray-500 dark:text-gray-400'}
                 `}>
                     {description ?? 'No Description Provided'}
                 </p>
+
+                <div>
+                    <Button
+                        size='xs'
+                        variant='secondary'
+                        className='!border-1'
+                        aria-label={`View the details of ${attractions[focusAttractionIndex].name}`}>
+                            View Details
+                    </Button>
+                </div>
             </div>
 
             {/* This is a hidden button to let image left side entire area to be clickable */}

--- a/app/containers/index/trip-timeline/image-carousel.css
+++ b/app/containers/index/trip-timeline/image-carousel.css
@@ -1,9 +1,0 @@
-.scrollbar-hide::-webkit-scrollbar {
-    display: none;
-}
-
-/* For IE, Edge and Firefox */
-.scrollbar-hide {
-    -ms-overflow-style: none; /* IE and Edge */
-    scrollbar-width: none; /* Firefox */
-}

--- a/app/containers/index/trip-timeline/image-carousel.css
+++ b/app/containers/index/trip-timeline/image-carousel.css
@@ -1,0 +1,34 @@
+@reference 'tailwindcss';
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
+
+.image-carousel__hidden-btn {
+    @apply absolute w-[50%] h-[75%] z-3 top-0;
+
+    & + button {
+        @apply absolute top-[calc(37.5%-1.625rem)] w-[1.5rem] z-4
+            transition-colors duration-250;
+
+        & > span {
+            @apply inline-flex items-center
+                px-0.5 py-4
+                text-blue-600 dark:text-yellow-300
+                bg-blue-500/20 dark:bg-yellow-300/50
+                transition-colors duration-250;
+        }
+    }
+}
+
+.image-carousel__hidden-btn:hover + button,
+.image-carousel__hidden-btn + button:focus,
+.image-carousel__hidden-btn + button:hover, {
+    & > span {
+        @apply
+            bg-blue-500 dark:bg-yellow-300
+            text-white dark:text-gray-800;
+    }
+}
+
+.image-carousel__hidden-btn + button:disabled > span {
+    @apply text-gray-400 bg-gray-200 
+        dark:text-gray-400 dark:bg-gray-700;
+}

--- a/app/containers/index/trip-timeline/image-carousel.tsx
+++ b/app/containers/index/trip-timeline/image-carousel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FC } from 'react';
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { trim } from '~/utils/trim';
 import { throttle } from '~/utils/throttle';
 
@@ -15,32 +15,41 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({ className }) => {
     const [scrollPercentage, setScrollPercentage] = useState(0);
     const carouselRef = useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
+    const [hydrated, setHydrated] = useState(false);
+
+    const handleScroll = useCallback(throttle(() => {
         const carousel = carouselRef.current;
         if (!carousel) return;
 
         const direction = window.getComputedStyle(carousel).direction as 'rtl' | 'ltr';
+        const { scrollWidth, clientWidth } = carousel;
 
-        const handleScroll = throttle(() => {
-            const { scrollWidth, clientWidth } = carousel;
+        /**
+         *  The reason why we apply absolute value is because if
+         *  the image carousel is in writing mode "rtl", the scrollLeft
+         *  will become negative value 
+         */
+        const scrollLeft = Math.abs(carousel.scrollLeft);
+        const scrollableWidth = scrollWidth - clientWidth;
+        const percentage = scrollLeft / scrollableWidth;
 
-            /**
-             *  The reason why we apply absolute value is because if
-             *  the image carousel is in writing mode "rtl", the scrollLeft
-             *  will become negative value 
-             */
-            const scrollLeft = Math.abs(carousel.scrollLeft);
-            const scrollableWidth = scrollWidth - clientWidth;
-            const percentage = scrollLeft / scrollableWidth;
+        setScrollPercentage(direction === 'ltr' ? percentage : 1 - percentage);
+    }, 100), []);
 
-            setScrollPercentage(direction === 'ltr' ? percentage : 1 - percentage);
-        }, 100);
+    useEffect(() => {
+        const carousel = carouselRef.current;
+        if (!carousel) return;
+
+        if (!hydrated) {
+            handleScroll();
+            setHydrated(true);
+        }
 
         carousel.addEventListener('scroll', handleScroll);
         return () => {
             carousel.removeEventListener('scroll', handleScroll);
         }
-    }, []);
+    }, [handleScroll, hydrated]);
 
     const leftGradientOpacity = scrollPercentage > .2 ? 1 : 1 - ((.2 - scrollPercentage) * 5);
     const rightGradientOpacity = scrollPercentage < .8 ? 1 : 1 - ((scrollPercentage - .8) * 5);

--- a/app/containers/index/trip-timeline/image-carousel.tsx
+++ b/app/containers/index/trip-timeline/image-carousel.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { CountryFlagIcon } from "~/icons/country/country";
 import { ChevronLeftOutlineIcon } from "~/icons/outline/chevron-left";
 import { ChevronRightOutlineIcon } from "~/icons/outline/chevron-right";
 import { MapPinOutlineIcon } from "~/icons/outline/map-pin";
 import { trim } from "~/utils/trim";
+import './image-carousel.css';
 
 export interface ImageCarouselProps {
     className?: string;
@@ -38,7 +39,10 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({
         } else {
             console.warn(`Unable to switch to "${direction}" image`);
         }
-    }
+    };
+
+    const disablePrevBtn = focusImgIndex === 0;
+    const disableNextBtn = focusImgIndex === images.length - 1;
 
     return (
         <div className={`relative w-full h-full px-[1.5rem] ${className}`}>
@@ -103,26 +107,44 @@ export const ImageCarousel: FC<ImageCarouselProps> = ({
                 </p>
             </div>
 
+            {/* This is a hidden button to let image left side entire area to be clickable */}
+            <div
+                role='button'
+                aria-hidden='true'
+                className={trim`
+                    image-carousel__hidden-btn
+                    direction-ltr left-0
+                `}
+                onClick={() => !disablePrevBtn && switchImageTo('prev')}
+            />
             <button className={trim`
-                direction-ltr text-left
-                absolute left-0 top-0 w-[50%] h-[75%] z-3
-                hover:text-blue-500
+                direction-ltr text-left left-0
             `}
+                disabled={disablePrevBtn}
                 onClick={() => switchImageTo('prev')}
             >
-                <span className='bg-gray-100 dark:bg-blue-500/30 rounded-l-sm px-0.5 py-4 inline-flex items-center'>
+                <span className='rounded-l-sm'>
                     <ChevronLeftOutlineIcon size='sm' className='inline-block' />
                 </span>
             </button>
 
+            {/* This is a hidden button to let image right side entire area to be clickable */}
+            <div
+                role='button'
+                aria-hidden='true'
+                className={trim`
+                    image-carousel__hidden-btn
+                    direction-ltr right-0
+                `}
+                onClick={() => !disableNextBtn && switchImageTo('next')}
+            />
             <button className={trim`
-                direction-ltr text-right
-                absolute right-0 top-0 w-[50%] h-[75%] z-3
-                hover:text-blue-500
+                direction-ltr text-right right-0
             `}
+                disabled={disableNextBtn}
                 onClick={() => switchImageTo('next')}
             >
-                <span className='bg-gray-100 dark:bg-blue-500/30 rounded-r-sm px-0.5 py-4 inline-flex items-center'>
+                <span className='rounded-r-sm'>
                     <ChevronRightOutlineIcon size='sm' className='inline-block' />
                 </span>
             </button>

--- a/app/containers/index/trip-timeline/image-swimlane.tsx
+++ b/app/containers/index/trip-timeline/image-swimlane.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState, type FC } from 'react';
+import { trim } from '~/utils/trim';
+import { throttle } from '~/utils/throttle';
+
+const images = Array.from(
+    { length: 5 },
+    (_, i) => `https://placehold.co/200x200?text=Image+${i + 1}`,
+);
+
+interface ImageSwimlaneProps {
+    className?: string;
+    width: string | number;
+    height: string | number;
+}
+
+export const ImageSwimlane: FC<ImageSwimlaneProps> = ({ className, width, height }) => {
+    const [scrollPercentage, setScrollPercentage] = useState(0);
+    const carouselRef = useRef<HTMLDivElement>(null);
+
+    const [hydrated, setHydrated] = useState(false);
+
+    const handleScroll = useCallback(throttle(() => {
+        const carousel = carouselRef.current;
+        if (!carousel) return;
+
+        const direction = window.getComputedStyle(carousel).direction as 'rtl' | 'ltr';
+        const { scrollWidth, clientWidth } = carousel;
+
+        /**
+         *  The reason why we apply absolute value is because if
+         *  the image carousel is in writing mode "rtl", the scrollLeft
+         *  will become negative value 
+         */
+        const scrollLeft = Math.abs(carousel.scrollLeft);
+        const scrollableWidth = scrollWidth - clientWidth;
+        const percentage = scrollLeft / scrollableWidth;
+
+        setScrollPercentage(direction === 'ltr' ? percentage : 1 - percentage);
+    }, 100), []);
+
+    useEffect(() => {
+        const carousel = carouselRef.current;
+        if (!carousel) return;
+
+        if (!hydrated) {
+            handleScroll();
+            setHydrated(true);
+        }
+
+        carousel.addEventListener('scroll', handleScroll);
+        return () => {
+            carousel.removeEventListener('scroll', handleScroll);
+        }
+    }, [handleScroll, hydrated]);
+
+    const leftGradientOpacity = scrollPercentage > .2 ? 1 : 1 - ((.2 - scrollPercentage) * 5);
+    const rightGradientOpacity = scrollPercentage < .8 ? 1 : 1 - ((scrollPercentage - .8) * 5);
+
+    width = typeof width === 'number' ? `${width}px` : width;
+    height = typeof height === 'number' ? `${height}px` : height;
+
+    return (
+        <div className={`${className} relative w-full overflow-x-auto`}>
+            <div
+                ref={el => {
+                    if (!el) return;
+                    carouselRef.current = el;
+                }}
+                className={trim`
+                    w-full overflow-x-auto whitespace-nowrap pb-2
+                `}
+            >
+                <ul className="inline-flex gap-[1rem] px-1.5">
+                    {images.map((src, index) => (
+                        /**
+                         *  flex: 0 0 auto means:
+                         *  - flex-shrink: 0
+                         *  - flex-grow: 0
+                         *  - flex-basis: auto
+                         *  Don’t grow or shrink -- stay exactly the size based on content or set dimensions
+                         **/
+                        <li key={index} className="flex-[0_0_auto]">
+                            <div
+                                className={trim`
+                                    rounded bg-cover bg-center bg-no-repeat
+                                    shadow-md shadow-gray-500 dark:shadow-blue-500
+                                `}
+                                style={{ backgroundImage: `url(${src})`, width, height }}
+                                role="img"
+                                aria-label={`Placeholder Image ${index + 1}`}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+
+            <div
+                className={trim`
+                    absolute top-0 left-0 pointer-events-none h-full w-6
+                    bg-gradient-to-r from-white dark:from-gray-900 to-transparent
+                `}
+                style={{ opacity: leftGradientOpacity }}
+            />
+
+            <div
+                className={trim`
+                    absolute top-0 right-0 pointer-events-none h-full w-6
+                    bg-gradient-to-l from-white dark:from-gray-900 to-transparent
+                `}
+                style={{ opacity: rightGradientOpacity }}
+            />
+        </div>
+    );
+};

--- a/app/containers/index/trip-timeline/image-swimlane.tsx
+++ b/app/containers/index/trip-timeline/image-swimlane.tsx
@@ -67,7 +67,8 @@ export const ImageSwimlane: FC<ImageSwimlaneProps> = ({ className, width, height
                     carouselRef.current = el;
                 }}
                 className={trim`
-                    w-full overflow-x-auto whitespace-nowrap pb-2
+                    w-full overflow-x-auto whitespace-nowrap
+                    scrollbar scrollbar-h-1 pb-2
                 `}
             >
                 <ul className="inline-flex gap-[1rem] px-1.5">

--- a/app/containers/index/trip-timeline/locations-swimlane.tsx
+++ b/app/containers/index/trip-timeline/locations-swimlane.tsx
@@ -10,38 +10,45 @@ interface LocationsSwimlaneProps {
         url: string;
         name: string;
         countryCode: string;
-    }>
+    }>;
 }
 
 export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
     className,
     width,
     height,
-    locations
+    locations,
 }) => {
     const [scrollPercentage, setScrollPercentage] = useState(0);
     const carouselRef = useRef<HTMLDivElement>(null);
 
     const [hydrated, setHydrated] = useState(false);
 
-    const handleScroll = useCallback(throttle(() => {
-        const carousel = carouselRef.current;
-        if (!carousel) return;
+    const handleScroll = useCallback(
+        throttle(() => {
+            const carousel = carouselRef.current;
+            if (!carousel) return;
 
-        const direction = window.getComputedStyle(carousel).direction as 'rtl' | 'ltr';
-        const { scrollWidth, clientWidth } = carousel;
+            const direction = window.getComputedStyle(carousel).direction as
+                | 'rtl'
+                | 'ltr';
+            const { scrollWidth, clientWidth } = carousel;
 
-        /**
-         *  The reason why we apply absolute value is because if
-         *  the image carousel is in writing mode "rtl", the scrollLeft
-         *  will become negative value 
-         */
-        const scrollLeft = Math.abs(carousel.scrollLeft);
-        const scrollableWidth = scrollWidth - clientWidth;
-        const percentage = scrollLeft / scrollableWidth;
+            /**
+             *  The reason why we apply absolute value is because if
+             *  the image carousel is in writing mode "rtl", the scrollLeft
+             *  will become negative value
+             */
+            const scrollLeft = Math.abs(carousel.scrollLeft);
+            const scrollableWidth = scrollWidth - clientWidth;
+            const percentage = scrollLeft / scrollableWidth;
 
-        setScrollPercentage(direction === 'ltr' ? percentage : 1 - percentage);
-    }, 100), []);
+            setScrollPercentage(
+                direction === 'ltr' ? percentage : 1 - percentage,
+            );
+        }, 100),
+        [],
+    );
 
     useEffect(() => {
         const carousel = carouselRef.current;
@@ -55,11 +62,13 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
         carousel.addEventListener('scroll', handleScroll);
         return () => {
             carousel.removeEventListener('scroll', handleScroll);
-        }
+        };
     }, [handleScroll, hydrated]);
 
-    const leftGradientOpacity = scrollPercentage > .2 ? 1 : 1 - ((.2 - scrollPercentage) * 5);
-    const rightGradientOpacity = scrollPercentage < .8 ? 1 : 1 - ((scrollPercentage - .8) * 5);
+    const leftGradientOpacity =
+        scrollPercentage > 0.2 ? 1 : 1 - (0.2 - scrollPercentage) * 5;
+    const rightGradientOpacity =
+        scrollPercentage < 0.8 ? 1 : 1 - (scrollPercentage - 0.8) * 5;
 
     width = typeof width === 'number' ? `${width}px` : width;
     height = typeof height === 'number' ? `${height}px` : height;
@@ -67,7 +76,7 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
     return (
         <div className={`${className} relative w-full overflow-x-auto`}>
             <div
-                ref={el => {
+                ref={(el) => {
                     if (!el) return;
                     carouselRef.current = el;
                 }}
@@ -95,16 +104,22 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                                     hover:shadow-md hover:shadow-gray-300 hover:dark:shadow-blue-500/50
                                     cursor-pointer
                                 `}
-                                style={{ backgroundImage: `url(${url})`, width, height }}
+                                style={{
+                                    backgroundImage: `url(${url})`,
+                                    width,
+                                    height,
+                                }}
                                 role="img"
                                 aria-label={`Image of ${name}`}
                             >
-                                <p className={trim`
+                                <p
+                                    className={trim`
                                     absolute bottom-0 left-0 px-2 pt-6 pb-1 w-full
                                     text-sm whitespace-normal line-clamp-2
                                     text-gray-700 dark:text-white tracking-wide font-light
                                     bg-gradient-to-t from-yellow-300 dark:from-blue-500 to-transparent
-                                `}>
+                                `}
+                                >
                                     {name}
                                 </p>
                             </div>

--- a/app/containers/index/trip-timeline/locations-swimlane.tsx
+++ b/app/containers/index/trip-timeline/locations-swimlane.tsx
@@ -2,18 +2,23 @@ import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { trim } from '~/utils/trim';
 import { throttle } from '~/utils/throttle';
 
-const images = Array.from(
-    { length: 5 },
-    (_, i) => `https://placehold.co/200x200?text=Image+${i + 1}`,
-);
-
-interface ImageSwimlaneProps {
+interface LocationsSwimlaneProps {
     className?: string;
     width: string | number;
     height: string | number;
+    locations: Array<{
+        url: string;
+        name: string;
+        countryCode: string;
+    }>
 }
 
-export const ImageSwimlane: FC<ImageSwimlaneProps> = ({ className, width, height }) => {
+export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
+    className,
+    width,
+    height,
+    locations
+}) => {
     const [scrollPercentage, setScrollPercentage] = useState(0);
     const carouselRef = useRef<HTMLDivElement>(null);
 
@@ -71,8 +76,8 @@ export const ImageSwimlane: FC<ImageSwimlaneProps> = ({ className, width, height
                     scrollbar scrollbar-h-1 pb-2
                 `}
             >
-                <ul className="inline-flex gap-[1rem] px-1.5">
-                    {images.map((src, index) => (
+                <ul className="inline-flex gap-[1rem] px-3 py-4">
+                    {locations.map(({ url, name, countryCode }) => (
                         /**
                          *  flex: 0 0 auto means:
                          *  - flex-shrink: 0
@@ -80,16 +85,29 @@ export const ImageSwimlane: FC<ImageSwimlaneProps> = ({ className, width, height
                          *  - flex-basis: auto
                          *  Don’t grow or shrink -- stay exactly the size based on content or set dimensions
                          **/
-                        <li key={index} className="flex-[0_0_auto]">
+                        <li key={name} className="flex-[0_0_auto]">
                             <div
                                 className={trim`
-                                    rounded bg-cover bg-center bg-no-repeat
-                                    shadow-md shadow-gray-500 dark:shadow-blue-500
+                                    relative rounded overflow-hidden
+                                    bg-cover bg-center bg-no-repeat
+                                    shadow-sm shadow-gray-400 dark:shadow-blue-500
+                                    transition-all duration-200 hover:scale-105
+                                    hover:shadow-md hover:shadow-gray-300 hover:dark:shadow-blue-500/50
+                                    cursor-pointer
                                 `}
-                                style={{ backgroundImage: `url(${src})`, width, height }}
+                                style={{ backgroundImage: `url(${url})`, width, height }}
                                 role="img"
-                                aria-label={`Placeholder Image ${index + 1}`}
-                            />
+                                aria-label={`Image of ${name}`}
+                            >
+                                <p className={trim`
+                                    absolute bottom-0 left-0 px-2 pt-6 pb-1 w-full
+                                    text-sm whitespace-normal text-balance line-clamp-2
+                                    text-gray-700 dark:text-white tracking-wide font-light
+                                    bg-gradient-to-t from-yellow-300 dark:from-blue-500 to-transparent
+                                `}>
+                                    {name}
+                                </p>
+                            </div>
                         </li>
                     ))}
                 </ul>

--- a/app/containers/index/trip-timeline/locations-swimlane.tsx
+++ b/app/containers/index/trip-timeline/locations-swimlane.tsx
@@ -101,7 +101,7 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                             >
                                 <p className={trim`
                                     absolute bottom-0 left-0 px-2 pt-6 pb-1 w-full
-                                    text-sm whitespace-normal text-balance line-clamp-2
+                                    text-sm whitespace-normal line-clamp-2
                                     text-gray-700 dark:text-white tracking-wide font-light
                                     bg-gradient-to-t from-yellow-300 dark:from-blue-500 to-transparent
                                 `}>

--- a/app/containers/index/trip-timeline/tag-list.tsx
+++ b/app/containers/index/trip-timeline/tag-list.tsx
@@ -22,6 +22,7 @@ export const TagList: FC<TagListProps> = ({ tags, className }) => {
                             rounded
                             px-1.5 py-0.5
                             cursor-pointer
+                            direction-ltr
                         `}
                         /**
                          *  TODO: In the future, we might want to change tag to

--- a/app/containers/index/trip-timeline/tag-list.tsx
+++ b/app/containers/index/trip-timeline/tag-list.tsx
@@ -1,0 +1,43 @@
+import type { FC } from "react";
+import { trim } from "~/utils/trim";
+
+export interface TagListProps {
+    tags: Array<string>;
+    className?: string;
+}
+
+export const TagList: FC<TagListProps> = ({ tags, className }) => {
+    return (
+        <>
+            <h4 className='sr-only'>Tags About This Trip</h4>
+            <ul className={`flex flex-row gap-x-2.5 gap-y-2 flex-wrap ${className}`}>
+                {tags.map(tag => (
+                    <li
+                        key={tag}
+                        className={trim`
+                            text-sm font-normal
+                            border-1 border-blue-500/50 dark:border-yellow-300/70
+                            hover:bg-blue-100/50 dark:hover:bg-yellow-100/20
+                            transition-colors duration-200 ease-in-out
+                            rounded
+                            px-1.5 py-0.5
+                            cursor-pointer
+                        `}
+                        /**
+                         *  TODO: In the future, we might want to change tag to
+                         *        act as clickable button for linking to search
+                         *        result on all trip/attractions ... etc under
+                         *        the same tag
+                         */
+                        // role='button'
+                    >
+                        <span aria-hidden='true' className='font-bold text-blue-500 dark:text-yellow-300'>
+                            #
+                        </span>{' '}
+                        {tag}
+                    </li>
+                ))}
+            </ul>
+        </>
+    );
+}

--- a/app/containers/index/trip-timeline/tag-list.tsx
+++ b/app/containers/index/trip-timeline/tag-list.tsx
@@ -1,5 +1,5 @@
-import type { FC } from "react";
-import { trim } from "~/utils/trim";
+import type { FC } from 'react';
+import { trim } from '~/utils/trim';
 
 export interface TagListProps {
     tags: Array<string>;
@@ -9,9 +9,11 @@ export interface TagListProps {
 export const TagList: FC<TagListProps> = ({ tags, className }) => {
     return (
         <>
-            <h4 className='sr-only'>Tags About This Trip</h4>
-            <ul className={`flex flex-row gap-x-2.5 gap-y-2 flex-wrap ${className}`}>
-                {tags.map(tag => (
+            <h4 className="sr-only">Tags About This Trip</h4>
+            <ul
+                className={`flex flex-row gap-x-2.5 gap-y-2 flex-wrap ${className}`}
+            >
+                {tags.map((tag) => (
                     <li
                         key={tag}
                         className={trim`
@@ -32,7 +34,10 @@ export const TagList: FC<TagListProps> = ({ tags, className }) => {
                          */
                         // role='button'
                     >
-                        <span aria-hidden='true' className='font-bold text-blue-300 dark:text-yellow-200'>
+                        <span
+                            aria-hidden="true"
+                            className="font-bold text-blue-300 dark:text-yellow-200"
+                        >
                             #
                         </span>{' '}
                         {tag}
@@ -41,4 +46,4 @@ export const TagList: FC<TagListProps> = ({ tags, className }) => {
             </ul>
         </>
     );
-}
+};

--- a/app/containers/index/trip-timeline/tag-list.tsx
+++ b/app/containers/index/trip-timeline/tag-list.tsx
@@ -16,7 +16,7 @@ export const TagList: FC<TagListProps> = ({ tags, className }) => {
                         key={tag}
                         className={trim`
                             text-sm font-normal
-                            border-1 border-blue-500/50 dark:border-yellow-300/70
+                            text-blue-500 dark:text-yellow-300
                             hover:bg-blue-100/50 dark:hover:bg-yellow-100/20
                             transition-colors duration-200 ease-in-out
                             rounded
@@ -32,7 +32,7 @@ export const TagList: FC<TagListProps> = ({ tags, className }) => {
                          */
                         // role='button'
                     >
-                        <span aria-hidden='true' className='font-bold text-blue-500 dark:text-yellow-300'>
+                        <span aria-hidden='true' className='font-bold text-blue-300 dark:text-yellow-200'>
                             #
                         </span>{' '}
                         {tag}

--- a/app/containers/index/trip-timeline/trip-introduction.tsx
+++ b/app/containers/index/trip-timeline/trip-introduction.tsx
@@ -1,10 +1,10 @@
-import { useMemo, type FC } from "react";
-import { Button } from "~/components/button";
-import { COUNTRY_INFO_MAP } from "~/data-access/country";
-import { CountryFlagChip } from "~/ui/country-flag-chip";
-import { TagList } from "./tag-list";
-import { trim } from "~/utils/trim";
-import { CalendarDateRangeOutlineIcon } from "~/icons/outline/calendar-date-range";
+import { useMemo, type FC } from 'react';
+import { Button } from '~/components/button';
+import { COUNTRY_INFO_MAP } from '~/data-access/country';
+import { CountryFlagChip } from '~/ui/country-flag-chip';
+import { TagList } from './tag-list';
+import { trim } from '~/utils/trim';
+import { CalendarDateRangeOutlineIcon } from '~/icons/outline/calendar-date-range';
 
 type Year = string;
 type Month = string;
@@ -14,17 +14,17 @@ type DateFormat = `${Year}-${Month}-${Day}`;
 function daysBetween(startDate: DateFormat, endDate: DateFormat) {
     const start = new Date(startDate);
     const end = new Date(endDate);
-  
+
     const diffTime = end.getTime() - start.getTime();
     const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
-  
+
     return diffDays;
 }
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
     month: 'long',
     day: 'numeric',
-    year: 'numeric'
+    year: 'numeric',
 });
 
 export interface TripIntroductionProps {
@@ -44,59 +44,72 @@ export const TripIntroduction: FC<TripIntroductionProps> = ({
     description,
     tags,
     countryCodes,
-    date: { from, to }
+    date: { from, to },
 }) => {
     const daysPassed = useMemo(() => daysBetween(from, to), [from, to]);
-    const formattedDate = useMemo(() => ({
-        from: dateFormatter.format(new Date(from)),
-        to: dateFormatter.format(new Date(to))
-    }), [from, to]);
+    const formattedDate = useMemo(
+        () => ({
+            from: dateFormatter.format(new Date(from)),
+            to: dateFormatter.format(new Date(to)),
+        }),
+        [from, to],
+    );
 
     return (
         <article className={`relative flex flex-col gap-y-1.5 ${className}`}>
-            <h3 className='text-2xl font-bold uppercase text-blue-500 dark:text-blue-400'>
+            <h3 className="text-2xl font-bold uppercase text-blue-500 dark:text-blue-400">
                 {title}
             </h3>
-            <p className={trim`
+            <p
+                className={trim`
                 text-lg font-medium tracking-wide line-clamp-2
                 text-gray-500 dark:text-gray-300
-            `}>
+            `}
+            >
                 {subtitle}
             </p>
 
-            <div className={trim`
+            <div
+                className={trim`
                 flex items-center gap-x-1.5 mt-1 mb-2
                 text-xs font-normal text-blue-500/80 dark:text-yellow-300
-            `}>
-                <CalendarDateRangeOutlineIcon size='sm' />
-                <span className='font-semibold font-header mr-1.5'>{daysPassed} DAYS</span>
+            `}
+            >
+                <CalendarDateRangeOutlineIcon size="sm" />
+                <span className="font-semibold font-header mr-1.5">
+                    {daysPassed} DAYS
+                </span>
                 <time dateTime={from}>{formattedDate.from}</time>
                 <span aria-hidden="true">~</span>
                 <time dateTime={to}>{formattedDate.to}</time>
-                <span className="sr-only">from {formattedDate.from} to {formattedDate.to}</span>
+                <span className="sr-only">
+                    from {formattedDate.from} to {formattedDate.to}
+                </span>
             </div>
 
-            <div className='flex flex-row flex-wrap gap-x-2 gap-y-1.5 mb-1'>
-                {countryCodes.map(cc => (
+            <div className="flex flex-row flex-wrap gap-x-2 gap-y-1.5 mb-1">
+                {countryCodes.map((cc) => (
                     <CountryFlagChip
                         key={cc}
-                        size='sm'
+                        size="sm"
                         countryCode={cc}
                         name={COUNTRY_INFO_MAP[cc].name}
-                        variant='horizontal'
-                        className='direction-ltr'
+                        variant="horizontal"
+                        className="direction-ltr"
                     />
                 ))}
             </div>
 
-            <p className='text-md tracking-wide font-light mb-4 line-clamp-3'>
+            <p className="text-md tracking-wide font-light mb-4 line-clamp-3">
                 {description}
             </p>
 
             {tags && <TagList tags={tags} />}
 
-            <div className='mt-4'>
-                <Button size='md' aria-label={`Explore More about ${title}`}>Explore More</Button>
+            <div className="mt-4">
+                <Button size="md" aria-label={`Explore More about ${title}`}>
+                    Explore More
+                </Button>
             </div>
 
             <span aria-hidden="true" className="timeline-dot" />

--- a/app/containers/index/trip-timeline/trip-introduction.tsx
+++ b/app/containers/index/trip-timeline/trip-introduction.tsx
@@ -1,0 +1,105 @@
+import { useMemo, type FC } from "react";
+import { Button } from "~/components/button";
+import { COUNTRY_INFO_MAP } from "~/data-access/country";
+import { CountryFlagChip } from "~/ui/country-flag-chip";
+import { TagList } from "./tag-list";
+import { trim } from "~/utils/trim";
+import { CalendarDateRangeOutlineIcon } from "~/icons/outline/calendar-date-range";
+
+type Year = string;
+type Month = string;
+type Day = string;
+type DateFormat = `${Year}-${Month}-${Day}`;
+
+function daysBetween(startDate: DateFormat, endDate: DateFormat) {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+  
+    const diffTime = end.getTime() - start.getTime();
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
+  
+    return diffDays;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric'
+});
+
+export interface TripIntroductionProps {
+    className?: string;
+    title: string;
+    subtitle: string;
+    description: string;
+    tags?: Array<string>;
+    countryCodes: Array<string>;
+    date: { from: DateFormat; to: DateFormat };
+}
+
+export const TripIntroduction: FC<TripIntroductionProps> = ({
+    className,
+    title,
+    subtitle,
+    description,
+    tags,
+    countryCodes,
+    date: { from, to }
+}) => {
+    const daysPassed = useMemo(() => daysBetween(from, to), [from, to]);
+    const formattedDate = useMemo(() => ({
+        from: dateFormatter.format(new Date(from)),
+        to: dateFormatter.format(new Date(to))
+    }), [from, to]);
+
+    return (
+        <article className={`relative flex flex-col gap-y-1.5 ${className}`}>
+            <h3 className='text-2xl font-bold uppercase text-blue-500 dark:text-blue-400'>
+                {title}
+            </h3>
+            <p className={trim`
+                text-lg font-medium tracking-wide line-clamp-2
+                text-gray-500 dark:text-gray-300
+            `}>
+                {subtitle}
+            </p>
+
+            <div className={trim`
+                flex items-center gap-x-1.5 mt-1 mb-2
+                text-xs font-normal text-blue-500/80 dark:text-yellow-300
+            `}>
+                <CalendarDateRangeOutlineIcon size='sm' />
+                <span className='font-semibold font-header mr-1.5'>{daysPassed} DAYS</span>
+                <time dateTime={from}>{formattedDate.from}</time>
+                <span aria-hidden="true">~</span>
+                <time dateTime={to}>{formattedDate.to}</time>
+                <span className="sr-only">from {formattedDate.from} to {formattedDate.to}</span>
+            </div>
+
+            <div className='flex flex-row flex-wrap gap-x-2 gap-y-1.5 mb-1'>
+                {countryCodes.map(cc => (
+                    <CountryFlagChip
+                        key={cc}
+                        size='sm'
+                        countryCode={cc}
+                        name={COUNTRY_INFO_MAP[cc].name}
+                        variant='horizontal'
+                        className='direction-ltr'
+                    />
+                ))}
+            </div>
+
+            <p className='text-md tracking-wide font-light mb-4 line-clamp-3'>
+                {description}
+            </p>
+
+            {tags && <TagList tags={tags} />}
+
+            <div className='mt-4'>
+                <Button size='md' aria-label={`Explore More about ${title}`}>Explore More</Button>
+            </div>
+
+            <span aria-hidden="true" className="timeline-dot" />
+        </article>
+    );
+};

--- a/app/containers/index/trip-timeline/trip-timeline-node.css
+++ b/app/containers/index/trip-timeline/trip-timeline-node.css
@@ -1,7 +1,6 @@
 @reference 'tailwindcss';
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
-
 .trip-timeline-node {
     @apply grid relative py-8;
     grid-template-columns: 1fr 1fr;

--- a/app/containers/index/trip-timeline/trip-timeline-node.css
+++ b/app/containers/index/trip-timeline/trip-timeline-node.css
@@ -13,19 +13,13 @@
         grid-area: image-carousel;
     }
 
-    & > div:nth-child(3) {
+    & > article {
         @apply relative;
         grid-area: trip-detail;
 
         & > span.timeline-dot::before {
-            @apply absolute left-[-2.25rem] top-0
+            @apply absolute left-[-2.25rem] top-0.5
                 inline-block w-6 h-6 bg-blue-500 rounded-full;
-            content: '';
-        }
-
-        & > span.timeline-dot::after {
-            @apply absolute left-[-2rem] top-[.25rem]
-                inline-block w-4 h-4 bg-white dark:bg-gray-900 rounded-full z-1;
             content: '';
         }
     }
@@ -47,11 +41,12 @@
         'image-carousel random-highlights'
         'trip-detail random-highlights';
 
-    & > div {
+    & > div,
+    & > article {
         direction: rtl;
     }
 
-    & > div:nth-child(3) {
+    & > article {
         & > span.timeline-dot::before {
             @apply right-[-2.25rem];
         }

--- a/app/containers/index/trip-timeline/trip-timeline-node.css
+++ b/app/containers/index/trip-timeline/trip-timeline-node.css
@@ -1,6 +1,7 @@
 @reference 'tailwindcss';
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
+
 .trip-timeline-node {
     @apply grid relative py-8;
     grid-template-columns: 1fr 1fr;
@@ -27,6 +28,10 @@
     & > .timeline-bar {
         @apply absolute left-0 right-0 top-0 mx-auto
             h-full w-1.25 bg-blue-500;
+    }
+
+    & + .trip-timeline-node {
+        @apply pt-24;
     }
 }
 

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 import { ImageCarousel } from './image-carousel';
 import { Button } from '~/components/button';
 import { TagList } from './tag-list';
+import { CountryFlagChip } from '~/ui/country-flag-chip';
 import './trip-timeline-node.css';
 
 export const TripTimelineNode: FC = () => {
@@ -18,6 +19,21 @@ export const TripTimelineNode: FC = () => {
                 <p className='text-lg font-normal tracking-wide text-gray-600 dark:text-gray-300'>
                     This is the trip's subtitle
                 </p>
+
+                <div className='flex flex-row flex-wrap gap-x-2 gap-y-1.5 mb-1'>
+                    <CountryFlagChip
+                        countryCode='us'
+                        name='United States'
+                        variant='horizontal'
+                        className='direction-ltr'
+                    />
+                    <CountryFlagChip
+                        countryCode='gb'
+                        name='United Kingdom'
+                        variant='horizontal'
+                        className='direction-ltr'
+                    />
+                </div>
 
                 <TagList
                     tags={['Tag A', 'Tag B', 'Tag C']}

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -1,16 +1,21 @@
-import type { FC } from 'react';
+import { useRef, type FC } from 'react';
 import { ImageSwimlane } from './image-swimlane';
 import { Button } from '~/components/button';
 import { TagList } from './tag-list';
 import { CountryFlagChip } from '~/ui/country-flag-chip';
 import { ImageCarousel } from './image-carousel';
+import { useIsMouseEntering } from '~/hooks/use-is-mouse-entering';
 import './trip-timeline-node.css';
 
 export const TripTimelineNode: FC = () => {
+    const timelineNodeRef = useRef<HTMLDivElement>(null);
+    const isMouseEnteringTimelineNode = useIsMouseEntering(timelineNodeRef);
+
     return (
-        <div className="trip-timeline-node">
+        <div className="trip-timeline-node" ref={timelineNodeRef}>
             {/* Attraction Highlights */}
             <ImageCarousel
+                autoplay={isMouseEnteringTimelineNode}
                 images={[
                     {
                         url: 'https://placehold.co/200x200?text=Photo+1',

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -1,16 +1,48 @@
 import type { FC } from 'react';
-import { ImageCarousel } from './image-carousel';
+import { ImageSwimlane } from './image-swimlane';
 import { Button } from '~/components/button';
 import { TagList } from './tag-list';
 import { CountryFlagChip } from '~/ui/country-flag-chip';
+import { ImageCarousel } from './image-carousel';
 import './trip-timeline-node.css';
 
 export const TripTimelineNode: FC = () => {
     return (
         <div className="trip-timeline-node">
-            <div>Random Highlights</div>
+            {/* Attraction Highlights */}
+            <ImageCarousel
+                images={[
+                    {
+                        url: 'https://placehold.co/200x200?text=Photo+1',
+                        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+                        location: {
+                            name: 'New York City, New York, USA',
+                            countryCode: 'us',
+                        }
+                    },
+                    {
+                        url: 'https://placehold.co/200x200?text=Photo+2',
+                        location: {
+                            name: 'New York City, New York, USA',
+                            countryCode: 'us',
+                        }
+                    },
+                    {
+                        url: 'https://placehold.co/200x200?text=Photo+3',
+                        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+                    },
+                    {
+                        url: 'https://placehold.co/200x200?text=Photo+4',
+                    }
+                ]}
+            />
 
-            <ImageCarousel className="my-6" />
+            {/* Travelled Cities Gallery Swimlane */}
+            <ImageSwimlane
+                className='my-6'
+                width={150}
+                height={150}
+            />
 
             <article className='relative flex flex-col gap-y-2'>
                 <h3 className='text-2xl font-bold uppercase text-blue-500 dark:text-blue-400'>

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -1,5 +1,7 @@
 import type { FC } from 'react';
 import { ImageCarousel } from './image-carousel';
+import { Button } from '~/components/button';
+import { TagList } from './tag-list';
 import './trip-timeline-node.css';
 
 export const TripTimelineNode: FC = () => {
@@ -9,10 +11,27 @@ export const TripTimelineNode: FC = () => {
 
             <ImageCarousel className="my-6" />
 
-            <div>
-                Title / Description
+            <article className='relative flex flex-col gap-y-2'>
+                <h3 className='text-xl font-bold uppercase'>
+                    Trip Title
+                </h3>
+
+                <TagList
+                    tags={['Tag A', 'Tag B', 'Tag C']}
+                />
+
+                <p className='text-md tracking-wide text-balance font-light my-4 line-clamp-3'>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                </p>
+
+                <div>
+                    <Button size='sm'>
+                        View Details
+                    </Button>
+                </div>
+
                 <span aria-hidden="true" className="timeline-dot" />
-            </div>
+            </article>
 
             <div className="timeline-bar" />
         </div>

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -17,12 +17,13 @@ export const TripTimelineNode: FC = () => {
                 attractions={[
                     {
                         url: 'https://placehold.co/200x200?text=Photo+1',
-                        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+                        description:
+                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
                         name: 'Attraction 1',
                         location: {
                             name: 'New York City, New York, USA',
                             countryCode: 'us',
-                        }
+                        },
                     },
                     {
                         url: 'https://placehold.co/200x200?text=Photo+2',
@@ -30,48 +31,49 @@ export const TripTimelineNode: FC = () => {
                         location: {
                             name: 'New York City, New York, USA',
                             countryCode: 'us',
-                        }
+                        },
                     },
                     {
                         url: 'https://placehold.co/200x200?text=Photo+3',
                         name: 'Attraction 3',
-                        description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+                        description:
+                            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
                     },
                     {
                         url: 'https://placehold.co/200x200?text=Photo+4',
                         name: 'Attraction 4',
-                    }
+                    },
                 ]}
             />
 
             {/* Travelled Cities Gallery Swimlane */}
             <LocationsSwimlane
-                className='mb-8'
+                className="mb-8"
                 width={150}
                 height={200}
                 locations={[
                     {
                         url: 'https://placehold.co/200x200?text=City+1',
                         name: 'New York City',
-                        countryCode: 'us'
+                        countryCode: 'us',
                     },
                     {
                         url: 'https://placehold.co/200x200?text=City+2',
                         name: 'Philadelphia',
-                        countryCode: 'us'
+                        countryCode: 'us',
                     },
                     {
                         url: 'https://placehold.co/200x200?text=City+3',
                         name: 'Washington D.C.',
-                        countryCode: 'us'
-                    }
+                        countryCode: 'us',
+                    },
                 ]}
             />
 
             <TripIntroduction
-                title='USA East Coast Capital Tour'
-                subtitle='Wandering Through the Financial & Political Center of USA'
-                description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+                title="USA East Coast Capital Tour"
+                subtitle="Wandering Through the Financial & Political Center of USA"
+                description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
                 tags={['Tag A', 'Tag B', 'Tag C']}
                 countryCodes={['us', 'gb']}
                 date={{ from: '2025-04-30', to: '2025-05-12' }}

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -1,10 +1,8 @@
 import { useRef, type FC } from 'react';
 import { LocationsSwimlane } from './locations-swimlane';
-import { Button } from '~/components/button';
-import { TagList } from './tag-list';
-import { CountryFlagChip } from '~/ui/country-flag-chip';
 import { AttractionsCarousel } from './attractions-carousel';
 import { useIsMouseEntering } from '~/hooks/use-is-mouse-entering';
+import { TripIntroduction } from './trip-introduction';
 import './trip-timeline-node.css';
 
 export const TripTimelineNode: FC = () => {
@@ -20,6 +18,7 @@ export const TripTimelineNode: FC = () => {
                     {
                         url: 'https://placehold.co/200x200?text=Photo+1',
                         description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+                        name: 'Attraction 1',
                         location: {
                             name: 'New York City, New York, USA',
                             countryCode: 'us',
@@ -27,6 +26,7 @@ export const TripTimelineNode: FC = () => {
                     },
                     {
                         url: 'https://placehold.co/200x200?text=Photo+2',
+                        name: 'Attraction 2',
                         location: {
                             name: 'New York City, New York, USA',
                             countryCode: 'us',
@@ -34,10 +34,12 @@ export const TripTimelineNode: FC = () => {
                     },
                     {
                         url: 'https://placehold.co/200x200?text=Photo+3',
+                        name: 'Attraction 3',
                         description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
                     },
                     {
                         url: 'https://placehold.co/200x200?text=Photo+4',
+                        name: 'Attraction 4',
                     }
                 ]}
             />
@@ -66,43 +68,14 @@ export const TripTimelineNode: FC = () => {
                 ]}
             />
 
-            <article className='relative flex flex-col gap-y-2'>
-                <h3 className='text-2xl font-bold uppercase text-blue-500 dark:text-blue-400'>
-                    Trip Title
-                </h3>
-                <p className='text-lg font-normal tracking-wide text-gray-600 dark:text-gray-300'>
-                    This is the trip's subtitle
-                </p>
-
-                <div className='flex flex-row flex-wrap gap-x-2 gap-y-1.5 mb-1'>
-                    <CountryFlagChip
-                        countryCode='us'
-                        name='United States'
-                        variant='horizontal'
-                        className='direction-ltr'
-                    />
-                    <CountryFlagChip
-                        countryCode='gb'
-                        name='United Kingdom'
-                        variant='horizontal'
-                        className='direction-ltr'
-                    />
-                </div>
-
-                <TagList
-                    tags={['Tag A', 'Tag B', 'Tag C']}
-                />
-
-                <p className='text-md tracking-wide text-balance font-light my-4 line-clamp-3'>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                </p>
-
-                <div>
-                    <Button size='sm'>Explore</Button>
-                </div>
-
-                <span aria-hidden="true" className="timeline-dot" />
-            </article>
+            <TripIntroduction
+                title='USA East Coast Capital Tour'
+                subtitle='Wandering Through the Financial & Political Center of USA'
+                description='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+                tags={['Tag A', 'Tag B', 'Tag C']}
+                countryCodes={['us', 'gb']}
+                date={{ from: '2025-04-30', to: '2025-05-12' }}
+            />
 
             <div className="timeline-bar" />
         </div>

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -1,9 +1,9 @@
 import { useRef, type FC } from 'react';
-import { ImageSwimlane } from './image-swimlane';
+import { LocationsSwimlane } from './locations-swimlane';
 import { Button } from '~/components/button';
 import { TagList } from './tag-list';
 import { CountryFlagChip } from '~/ui/country-flag-chip';
-import { ImageCarousel } from './image-carousel';
+import { AttractionsCarousel } from './attractions-carousel';
 import { useIsMouseEntering } from '~/hooks/use-is-mouse-entering';
 import './trip-timeline-node.css';
 
@@ -14,9 +14,9 @@ export const TripTimelineNode: FC = () => {
     return (
         <div className="trip-timeline-node" ref={timelineNodeRef}>
             {/* Attraction Highlights */}
-            <ImageCarousel
+            <AttractionsCarousel
                 autoplay={isMouseEnteringTimelineNode}
-                images={[
+                attractions={[
                     {
                         url: 'https://placehold.co/200x200?text=Photo+1',
                         description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
@@ -43,10 +43,27 @@ export const TripTimelineNode: FC = () => {
             />
 
             {/* Travelled Cities Gallery Swimlane */}
-            <ImageSwimlane
-                className='my-6'
+            <LocationsSwimlane
+                className='mb-8'
                 width={150}
-                height={150}
+                height={200}
+                locations={[
+                    {
+                        url: 'https://placehold.co/200x200?text=City+1',
+                        name: 'New York City',
+                        countryCode: 'us'
+                    },
+                    {
+                        url: 'https://placehold.co/200x200?text=City+2',
+                        name: 'Philadelphia',
+                        countryCode: 'us'
+                    },
+                    {
+                        url: 'https://placehold.co/200x200?text=City+3',
+                        name: 'Washington D.C.',
+                        countryCode: 'us'
+                    }
+                ]}
             />
 
             <article className='relative flex flex-col gap-y-2'>

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -12,9 +12,12 @@ export const TripTimelineNode: FC = () => {
             <ImageCarousel className="my-6" />
 
             <article className='relative flex flex-col gap-y-2'>
-                <h3 className='text-xl font-bold uppercase'>
+                <h3 className='text-2xl font-bold uppercase text-blue-500 dark:text-blue-400'>
                     Trip Title
                 </h3>
+                <p className='text-lg font-normal tracking-wide text-gray-600 dark:text-gray-300'>
+                    This is the trip's subtitle
+                </p>
 
                 <TagList
                     tags={['Tag A', 'Tag B', 'Tag C']}
@@ -25,9 +28,7 @@ export const TripTimelineNode: FC = () => {
                 </p>
 
                 <div>
-                    <Button size='sm'>
-                        View Details
-                    </Button>
+                    <Button size='sm'>Explore</Button>
                 </div>
 
                 <span aria-hidden="true" className="timeline-dot" />

--- a/app/containers/index/trip-timeline/trip-timeline.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline.tsx
@@ -36,7 +36,7 @@ export const TripTimeline: FC<TripTimelineProps> = ({ className }) => {
                 />
 
                 <TripTimelineNode />
-                <TripTimelineNode debug />
+                <TripTimelineNode />
                 <TripTimelineNode />
 
                 <div className="flex flex-col items-center relative pt-15">

--- a/app/containers/index/trip-timeline/trip-timeline.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline.tsx
@@ -36,7 +36,7 @@ export const TripTimeline: FC<TripTimelineProps> = ({ className }) => {
                 />
 
                 <TripTimelineNode />
-                <TripTimelineNode />
+                <TripTimelineNode debug />
                 <TripTimelineNode />
 
                 <div className="flex flex-col items-center relative pt-15">

--- a/app/hooks/use-hydration.ts
+++ b/app/hooks/use-hydration.ts
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 /**
- *  Function which returns state on page is client hydrated 
+ *  Function which returns state on page is client hydrated
  */
 export function useHydration() {
     const [isHydrated, setIsHydrated] = useState(false);

--- a/app/hooks/use-hydration.ts
+++ b/app/hooks/use-hydration.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+/**
+ *  Function which returns state on page is client hydrated 
+ */
+export function useHydration() {
+    const [isHydrated, setIsHydrated] = useState(false);
+
+    useEffect(() => {
+        setIsHydrated(true);
+    }, []);
+
+    return isHydrated;
+}

--- a/app/hooks/use-is-mouse-entering.tsx
+++ b/app/hooks/use-is-mouse-entering.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useState, type RefObject } from "react";
-import { useHydration } from "./use-hydration";
+import { useEffect, useState, type RefObject } from 'react';
+import { useHydration } from './use-hydration';
 
 /**
  *  This hook detects whether the mouse is entering some specific
- *  ref UI 
+ *  ref UI
  */
-export function useIsMouseEntering<T extends HTMLElement>(ref: RefObject<T | null>) {
+export function useIsMouseEntering<T extends HTMLElement>(
+    ref: RefObject<T | null>,
+) {
     const [isMouseEntered, setIsMouseEntered] = useState(false);
     const isHydrated = useHydration();
 
@@ -15,10 +17,10 @@ export function useIsMouseEntering<T extends HTMLElement>(ref: RefObject<T | nul
 
         function mouseEnterHandler() {
             setIsMouseEntered(true);
-        };
+        }
         function mouseLeaveHandler() {
             setIsMouseEntered(false);
-        };
+        }
         el.addEventListener('mouseenter', mouseEnterHandler);
         el.addEventListener('mouseleave', mouseLeaveHandler);
 

--- a/app/hooks/use-is-mouse-entering.tsx
+++ b/app/hooks/use-is-mouse-entering.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState, type RefObject } from "react";
+import { useHydration } from "./use-hydration";
+
+/**
+ *  This hook detects whether the mouse is entering some specific
+ *  ref UI 
+ */
+export function useIsMouseEntering<T extends HTMLElement>(ref: RefObject<T | null>) {
+    const [isMouseEntered, setIsMouseEntered] = useState(false);
+    const isHydrated = useHydration();
+
+    useEffect(() => {
+        if (!isHydrated || !ref.current) return;
+        const el = ref.current;
+
+        function mouseEnterHandler() {
+            setIsMouseEntered(true);
+        };
+        function mouseLeaveHandler() {
+            setIsMouseEntered(false);
+        };
+        el.addEventListener('mouseenter', mouseEnterHandler);
+        el.addEventListener('mouseleave', mouseLeaveHandler);
+
+        return () => {
+            el.removeEventListener('mouseenter', mouseEnterHandler);
+            el.removeEventListener('mouseleave', mouseLeaveHandler);
+        };
+    }, [isHydrated]);
+
+    return isMouseEntered;
+}

--- a/app/icons/outline/chevron-left.tsx
+++ b/app/icons/outline/chevron-left.tsx
@@ -6,7 +6,18 @@ export const ChevronLeftOutlineIcon: FC<IconProps> = ({
     size = 'md',
     className = '',
 }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`${sizeMapping[size]} ${className}`}>
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={`${sizeMapping[size]} ${className}`}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15.75 19.5 8.25 12l7.5-7.5"
+        />
     </svg>
 );

--- a/app/icons/outline/chevron-left.tsx
+++ b/app/icons/outline/chevron-left.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react';
+import type { IconProps } from '../type';
+import { sizeMapping } from '../const';
+
+export const ChevronLeftOutlineIcon: FC<IconProps> = ({
+    size = 'md',
+    className = '',
+}) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`${sizeMapping[size]} ${className}`}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+    </svg>
+);

--- a/app/icons/outline/chevron-right.tsx
+++ b/app/icons/outline/chevron-right.tsx
@@ -6,7 +6,18 @@ export const ChevronRightOutlineIcon: FC<IconProps> = ({
     size = 'md',
     className = '',
 }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`${sizeMapping[size]} ${className}`}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={`${sizeMapping[size]} ${className}`}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m8.25 4.5 7.5 7.5-7.5 7.5"
+        />
     </svg>
 );

--- a/app/icons/outline/chevron-right.tsx
+++ b/app/icons/outline/chevron-right.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react';
+import type { IconProps } from '../type';
+import { sizeMapping } from '../const';
+
+export const ChevronRightOutlineIcon: FC<IconProps> = ({
+    size = 'md',
+    className = '',
+}) => (
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`${sizeMapping[size]} ${className}`}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+    </svg>
+);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,6 +29,7 @@ import {
 
 import './app.css';
 import { trim } from './utils/trim';
+import { useEffect } from 'react';
 
 export const links: Route.LinksFunction = () => [];
 
@@ -54,6 +55,12 @@ export async function loader({ request }: Route.LoaderArgs) {
 export function App() {
     const data = useLoaderData();
     const [theme] = useTheme();
+
+    useEffect(() => {
+        document.addEventListener('copy', e => {
+            e.preventDefault();
+        });
+    }, []);
 
     return (
         <html

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -57,7 +57,7 @@ export function App() {
     const [theme] = useTheme();
 
     useEffect(() => {
-        document.addEventListener('copy', e => {
+        document.addEventListener('copy', (e) => {
             e.preventDefault();
         });
     }, []);

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -24,8 +24,8 @@ export default function Home() {
             <TravelHighlight className="my-0 mx-auto max-w-[960px]" />
             <TravelStats className="my-0 mx-auto max-w-[960px] pt-12" />
 
-            <p className='hidden mx-auto mt-[4rem] md:block text-center max-w-[960px] opacity-50'>
-                🚧 My Journey Timeline is Currently Under Construction 🚧 <br/>
+            <p className="hidden mx-auto mt-[4rem] md:block text-center max-w-[960px] opacity-50">
+                🚧 My Journey Timeline is Currently Under Construction 🚧 <br />
                 😊 Following is a Preview Version 😊
             </p>
             <TripTimeline

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -24,7 +24,7 @@ export default function Home() {
             <TravelHighlight className="my-0 mx-auto max-w-[960px]" />
             <TravelStats className="my-0 mx-auto max-w-[960px] pt-12" />
 
-            <p className='hidden mx-auto mt-[4rem] md:block text-center max-w-[960px] text-balance opacity-50'>
+            <p className='hidden mx-auto mt-[4rem] md:block text-center max-w-[960px] opacity-50'>
                 🚧 My Journey Timeline is Currently Under Construction 🚧 <br/>
                 😊 Following is a Preview Version 😊
             </p>

--- a/app/ui/country-flag-chip.tsx
+++ b/app/ui/country-flag-chip.tsx
@@ -29,7 +29,7 @@ export const CountryFlagChip: FC<CountryFlagChip> = ({
                 className: '!px-0.5 !py-0.5',
                 variant: 'tertiary',
             }}
-            tooltip={<p className="text-sm text-balance text-center">{name}</p>}
+            tooltip={<p className="text-sm text-center">{name}</p>}
         >
             <div
                 className={trim`

--- a/app/ui/country-flag-chip.tsx
+++ b/app/ui/country-flag-chip.tsx
@@ -1,0 +1,53 @@
+import type { FC } from "react"
+import { Tooltip } from "~/components/tooltip"
+import { CountryFlagIcon, type CountryFlagIconProps } from "~/icons/country/country";
+import { trim } from "~/utils/trim";
+
+interface CountryFlagChip {
+    className?: string;
+    countryFlagIconClassName?: string;
+    countryCode: string;
+    name: string;
+    onClick?: (countryCode: string) => void;
+    size?: CountryFlagIconProps['size'];
+    variant?: 'vertical' | 'horizontal';
+}
+
+export const CountryFlagChip: FC<CountryFlagChip> = ({
+    className,
+    countryFlagIconClassName = '',
+    countryCode,
+    name,
+    onClick,
+    size = 'md',
+    variant = 'vertical'
+}) => {
+    return (
+        <Tooltip
+            key={countryCode}
+            triggerButtonProps={{
+                className: '!px-0.5 !py-0.5',
+                variant: 'tertiary',
+            }}
+            tooltip={<p className="text-sm text-balance text-center">{name}</p>}
+        >
+            <div
+                className={trim`
+                    flex ${variant === 'vertical' ? 'flex-col' : 'flex-row'} items-center
+                    ${variant === 'horizontal' ? 'gap-x-2' : ''}
+                    ${className}
+                `}
+                onClick={() => onClick?.(countryCode)}
+            >
+                <CountryFlagIcon
+                    countryCode={countryCode}
+                    size={size}
+                    className={`rounded ${countryFlagIconClassName}`}
+                />
+                <p className="text-xs text-center uppercase font-header mt-0.5">
+                    {countryCode}
+                </p>
+            </div>
+        </Tooltip>
+    );
+}

--- a/app/ui/country-flag-chip.tsx
+++ b/app/ui/country-flag-chip.tsx
@@ -1,7 +1,10 @@
-import type { FC } from "react"
-import { Tooltip } from "~/components/tooltip"
-import { CountryFlagIcon, type CountryFlagIconProps } from "~/icons/country/country";
-import { trim } from "~/utils/trim";
+import type { FC } from 'react';
+import { Tooltip } from '~/components/tooltip';
+import {
+    CountryFlagIcon,
+    type CountryFlagIconProps,
+} from '~/icons/country/country';
+import { trim } from '~/utils/trim';
 
 interface CountryFlagChip {
     className?: string;
@@ -20,7 +23,7 @@ export const CountryFlagChip: FC<CountryFlagChip> = ({
     name,
     onClick,
     size = 'md',
-    variant = 'vertical'
+    variant = 'vertical',
 }) => {
     return (
         <Tooltip
@@ -50,4 +53,4 @@ export const CountryFlagChip: FC<CountryFlagChip> = ({
             </div>
         </Tooltip>
     );
-}
+};


### PR DESCRIPTION
This pull creates the rest of the backbone of the travel timeline view in the Home page.

- the image carousel is now renamed as image swimlane and would be served for displaying cities been to during some trip
- the travel detail contains title, subtitle, travelled countries, tags, description and an `Explore More` button
- the image carousel is served as displaying key attractions during this trip

<img width="1094" alt="Screenshot 2025-07-06 at 01 27 10" src="https://github.com/user-attachments/assets/164f3755-8deb-4da3-aae8-0bd43521a693" />
<img width="1025" alt="Screenshot 2025-07-06 at 01 27 16" src="https://github.com/user-attachments/assets/829c5d93-55a3-44e0-b525-60bb7948068a" />
