### PR TITLE
NOTICKET: Try Fixing Broken Style of Region Background Wrapper in Home Page

### DIFF
--- a/app/containers/index/travel-stats/region-background-wrapper.tsx
+++ b/app/containers/index/travel-stats/region-background-wrapper.tsx
@@ -15,8 +15,7 @@ export const RegionBackgroundWrapper: FC<
         <div
             className={trim`
                 overflow-x-hidden relative w-full
-                bg-cover xs:bg-contain bg-no-repeat
-                ${className}
+                bg-no-repeat ${className}
             `}
             style={{
                 backgroundImage: `url('${IMG_BASE_URL}/${backgroundImageURL}')`,

--- a/app/containers/index/travel-stats/travel-stats.css
+++ b/app/containers/index/travel-stats/travel-stats.css
@@ -37,12 +37,19 @@
     }
 }
 
+/**
+ *  Not sure the reason why we have to separate this part out of the region
+ *  background wrapper in order to fix style consistancy explicity
+ */
+.travel-stats__bg {
+    @apply bg-cover xs:bg-contain;    
+}
+
 /* Region Background Image Position */
 .travel-stats__eu-bg {
     @apply h-[350px] md:h-[500px]
         bg-[right_-3.5rem_top_-3rem]
         xs:bg-[right_0rem_center];
-
     & > div {
         @apply top-[20%] sm:top-[2.5%] md:top-[12.5%]
             left-[5%] xs:left-[12%] sm:left-[7.5%] md:left-[5%];

--- a/app/containers/index/travel-stats/travel-stats.tsx
+++ b/app/containers/index/travel-stats/travel-stats.tsx
@@ -64,7 +64,7 @@ export const TravelStats: FC<TravelStatsProps> = ({ className }) => {
             </h2>
 
             <RegionBackgroundWrapper
-                className="travel-stats__eu-bg"
+                className="travel-stats__bg travel-stats__eu-bg"
                 backgroundImageURL="region/europe.v3.svg"
             >
                 <TravelledCountriesCounter
@@ -145,7 +145,7 @@ export const TravelStats: FC<TravelStatsProps> = ({ className }) => {
             </div> */}
 
             <RegionBackgroundWrapper
-                className="travel-stats__asia-bg"
+                className="travel-stats__bg travel-stats__asia-bg"
                 backgroundImageURL="region/asia.svg"
             >
                 <TravelledCountriesCounter
@@ -164,7 +164,7 @@ export const TravelStats: FC<TravelStatsProps> = ({ className }) => {
             </RegionBackgroundWrapper>
 
             <RegionBackgroundWrapper
-                className="travel-stats__central-north-america-bg"
+                className="travel-stats__bg travel-stats__central-north-america-bg"
                 backgroundImageURL="region/central-north-america.v3.svg"
             >
                 <TravelledCountriesCounter
@@ -183,7 +183,7 @@ export const TravelStats: FC<TravelStatsProps> = ({ className }) => {
             </RegionBackgroundWrapper>
 
             <RegionBackgroundWrapper
-                className="travel-stats__africa-bg"
+                className="travel-stats__bg travel-stats__africa-bg"
                 backgroundImageURL="region/africa.svg"
             >
                 <TravelledCountriesCounter


### PR DESCRIPTION
Currently the region background image in home page has broken style where `bg-cover` and `xs:bg-contain` seems not be working, this pull tries to resolve this issue.

Before:
<img width="1144" alt="Screenshot 2025-07-07 at 02 00 10" src="https://github.com/user-attachments/assets/64a94e59-61ea-4717-ab0e-7bb9ea765f4e" />

Expected:
<img width="1033" alt="Screenshot 2025-07-07 at 02 00 21" src="https://github.com/user-attachments/assets/ddcdee4d-6b67-4c34-aa56-76119f4350b3" />
