### PR TITLE
NOTICKET: Fix Dependency Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "react-router": "7.1.5",
         "remix-themes": "^2.0.4",
         "remix-utils": "^8.1.0",
+        "node-fetch": "^3.3.2",
         "zod": "^3.24.2"
     },
     "devDependencies": {
@@ -57,7 +58,6 @@
         "dotenv": "^17.2.0",
         "execa": "^9.6.0",
         "inquirer": "^12.7.0",
-        "node-fetch": "^3.3.2",
         "playwright": "^1.53.1",
         "postcss": "^8.5.6",
         "postcss-nesting": "^13.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       maplibre-gl:
         specifier: ^5.6.1
         version: 5.6.1
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
       pmtiles:
         specifier: ^4.3.0
         version: 4.3.0
@@ -126,9 +129,6 @@ importers:
       inquirer:
         specifier: ^12.7.0
         version: 12.7.0(@types/node@20.17.17)
-      node-fetch:
-        specifier: ^3.3.2
-        version: 3.3.2
       playwright:
         specifier: ^1.53.1
         version: 1.53.1


### PR DESCRIPTION
## Description

NOTICKET

This pull is to move `node-fetch` from dev dependency to normal dependency as it is required for production build.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Other: ______

## How Has This Been Tested?

- [x] Created production build and tested locally
- [ ] Other: ______

## Solution

- [x] Move `node-fetch` to production dependency

## Screenshots

No screenshots needed.