### PR TITLE
fix: able to rerun docker

### DIFF
--- a/app/components/map/map-route.tsx
+++ b/app/components/map/map-route.tsx
@@ -3,14 +3,16 @@ import {
     useCallback,
     useEffect,
     useImperativeHandle,
-    useMemo,
     useRef,
 } from 'react';
 import type { UseMapInstanceType } from './create-map-components';
 import { usePrevious } from '~/hooks/use-previous';
 import { Theme, useTheme } from 'remix-themes';
-import colors from 'tailwindcss/colors';
 import { formatRgb as rgb } from 'culori';
+
+// TODO: check if we could reduce bundle size by avoiding importing
+//       stuff from tailwindcss and instead populate the color in code
+import colors from 'tailwindcss/colors';
 
 type Coordinate = [lat: number, lng: number];
 

--- a/bin/generate-route.js
+++ b/bin/generate-route.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import inquirer from 'inquirer';
-import fetch from 'node-fetch';
 import dotenv from 'dotenv';
 import { writeFile } from 'fs/promises';
 import { execa } from 'execa';

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "react-router": "7.1.5",
         "remix-themes": "^2.0.4",
         "remix-utils": "^8.1.0",
-        "node-fetch": "^3.3.2",
+        "tailwindcss": "4.0.0",
         "zod": "^3.24.2"
     },
     "devDependencies": {
@@ -65,7 +65,6 @@
         "react-router-devtools": "1.1.0",
         "storybook": "^9.0.12",
         "tailwind-scrollbar": "^4.0.2",
-        "tailwindcss": "4.0.0",
         "typescript": "5.7.2",
         "vite": "5.4.11",
         "vite-tsconfig-paths": "5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       remix-utils:
         specifier: ^8.1.0
         version: 8.1.0(@oslojs/crypto@1.0.1)(@oslojs/encoding@1.1.0)(react-router@7.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(zod@3.24.2)
+      tailwindcss:
+        specifier: 4.0.0
+        version: 4.0.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -150,9 +153,6 @@ importers:
       tailwind-scrollbar:
         specifier: ^4.0.2
         version: 4.0.2(react@19.0.0)(tailwindcss@4.0.0)
-      tailwindcss:
-        specifier: 4.0.0
-        version: 4.0.0
       typescript:
         specifier: 5.7.2
         version: 5.7.2


### PR DESCRIPTION
## Description

NOTICKET

The cause of docker not able to build image success is because `tailwindcss` is also list as dev dependency; however, in the future, probably we would want to avoid importing the whole tailwindcss inside the production bundle.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Other: ______

## How Has This Been Tested?

- [x] Created production build and tested locally
- [ ] Other: ______

## Solution

- [x] Move `tailwindcss` to production dependency

## Screenshots

No screenshots needed.