### PR TITLE
ISSUE-33: Setup & Navigation to LDP

### DIFF
--- a/app/containers/index/trip-timeline/locations-swimlane.tsx
+++ b/app/containers/index/trip-timeline/locations-swimlane.tsx
@@ -1,16 +1,13 @@
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { trim } from '~/utils/trim';
 import { throttle } from '~/utils/throttle';
+import type { TripDetails } from '~/data-access/trips';
 
 interface LocationsSwimlaneProps {
     className?: string;
     width: string | number;
     height: string | number;
-    locations: Array<{
-        url: string;
-        name: string;
-        countryCode: string;
-    }>;
+    locations: TripDetails['locations'];
 }
 
 export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
@@ -87,7 +84,7 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                 `}
             >
                 <ul className="inline-flex gap-[1rem] px-3 py-4">
-                    {locations.map(({ url, name, countryCode }) => (
+                    {locations.map(({ name }) => (
                         /**
                          *  flex: 0 0 auto means:
                          *  - flex-shrink: 0
@@ -106,7 +103,10 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                                     cursor-pointer
                                 `}
                                 style={{
-                                    backgroundImage: `url(${url})`,
+                                    /**
+                                     *  TODO: Use the real image data
+                                     */
+                                    backgroundImage: `url(https://placehold.co/200x200?text=${name.split(' ').join('-')})`,
                                     width,
                                     height,
                                 }}

--- a/app/containers/index/trip-timeline/locations-swimlane.tsx
+++ b/app/containers/index/trip-timeline/locations-swimlane.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { trim } from '~/utils/trim';
 import { throttle } from '~/utils/throttle';
 import type { TripDetails } from '~/data-access/trips';
+import { Link } from 'react-router';
 
 interface LocationsSwimlaneProps {
     className?: string;
@@ -84,7 +85,7 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                 `}
             >
                 <ul className="inline-flex gap-[1rem] px-3 py-4">
-                    {locations.map(({ name }) => (
+                    {locations.map(({ name, nameId }) => (
                         /**
                          *  flex: 0 0 auto means:
                          *  - flex-shrink: 0
@@ -95,7 +96,7 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                         <li key={name} className="flex-[0_0_auto]">
                             <div
                                 className={trim`
-                                    relative rounded overflow-hidden
+                                    relative rounded
                                     bg-cover bg-center bg-no-repeat
                                     shadow-sm shadow-gray-400 dark:shadow-blue-500
                                     transition-all duration-200 hover:scale-105
@@ -123,6 +124,16 @@ export const LocationsSwimlane: FC<LocationsSwimlaneProps> = ({
                                 >
                                     {name}
                                 </p>
+
+                                <Link
+                                    aria-label={`View more details about ${name}`}
+                                    className={trim`
+                                        absolute inline-block w-full h-full left-0 top-0 rounded
+                                        focus:ring-4 focus:ring-offset-4 focus:ring-blue-500
+                                        focus:ring-offset-white dark:focus:ring-offset-gray-900
+                                    `}
+                                    to={`/location/${nameId}`}
+                                />
                             </div>
                         </li>
                     ))}

--- a/app/containers/index/trip-timeline/trip-timeline-node.tsx
+++ b/app/containers/index/trip-timeline/trip-timeline-node.tsx
@@ -59,23 +59,7 @@ export const TripTimelineNode: FC<TripTimelineNodeProps> = ({
                 className="mb-8"
                 width={150}
                 height={200}
-                locations={[
-                    {
-                        url: 'https://placehold.co/200x200?text=City+1',
-                        name: 'New York City',
-                        countryCode: 'us',
-                    },
-                    {
-                        url: 'https://placehold.co/200x200?text=City+2',
-                        name: 'Philadelphia',
-                        countryCode: 'us',
-                    },
-                    {
-                        url: 'https://placehold.co/200x200?text=City+3',
-                        name: 'Washington D.C.',
-                        countryCode: 'us',
-                    },
-                ]}
+                locations={tripDetails.locations}
             />
 
             <TripIntroduction {...tripDetails} />

--- a/app/containers/trip-details-page/trip-route-location-detail.tsx
+++ b/app/containers/trip-details-page/trip-route-location-detail.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, type HTMLProps } from 'react';
-import { Button } from '~/components/button';
+import { NavLink } from '~/components/nav-link';
 import { dateFormatter } from '~/data-access/date';
 import type { TripLocation } from '~/data-access/trips';
 import { trim } from '~/utils/trim';
@@ -48,9 +48,14 @@ export const TripRouteLocationDetail = forwardRef<
                 <p className="text-base font-light">{description}</p>
 
                 <span className="self-end">
-                    <Button variant="secondary" size="xs">
-                        View Details (WIP)
-                    </Button>
+                    <NavLink
+                        variant="secondary"
+                        size="xs"
+                        to={`/location/${location.nameId}`}
+                        aria-label={`View more details of ${location.name}`}
+                    >
+                        View Details
+                    </NavLink>
                 </span>
             </div>
         </div>

--- a/app/containers/trip-details-page/trip-route-location-detail.tsx
+++ b/app/containers/trip-details-page/trip-route-location-detail.tsx
@@ -22,7 +22,7 @@ export const TripRouteLocationDetail = forwardRef<
 
     return (
         <div {...props} ref={ref}>
-            <div className="w-full h-[30vh]" />
+            <div className="w-full h-[30vh] pointer-events-none" />
             <div
                 className={trim`
                     flex flex-col gap-y-[1rem] mb-[-30vh]

--- a/app/containers/trip-details-page/trip-route-map.tsx
+++ b/app/containers/trip-details-page/trip-route-map.tsx
@@ -22,8 +22,18 @@ export interface TripRouteMapProps {
     className?: string;
 }
 
-const INIT_ZOOM = 7;
-const LOCATION_FOCUS_ZOOM = 8;
+/**
+ *   The offset is an estimate to offset the center so that it
+ *   is visually balanced when showing the location on the map
+ *   on slightly righter side
+ **/
+const zoomLevelFocusOffset: Record<number, number> = {
+    12: 0.035,
+    11: 0.1,
+    10: 0.15,
+    8: 0.5,
+};
+
 const LOCATION_FOCUS_DURATION = 1000;
 
 export const TripRouteMap: FC<TripRouteMapProps> = ({ className }) => {
@@ -42,12 +52,12 @@ export const TripRouteMap: FC<TripRouteMapProps> = ({ className }) => {
     const isAnimationRestoredRef = useRef(false);
 
     const {
-        date: { from, to },
+        // date: { from, to },
         map: mapOptions,
         locations,
     } = tripDetails;
 
-    const { center: mapOriginalCenter } = mapOptions;
+    const { center: mapOriginalCenter, zoomLevel } = mapOptions;
 
     const mapPins = useMemo(
         () =>
@@ -78,24 +88,20 @@ export const TripRouteMap: FC<TripRouteMapProps> = ({ className }) => {
             if (index === 'origin') {
                 mapInstance.flyTo({
                     center: mapOriginalCenter,
-                    zoom: INIT_ZOOM,
+                    zoom: zoomLevel.init,
                     duration: LOCATION_FOCUS_DURATION,
                     essential: true,
                 });
                 return;
             }
 
-            /**
-             *   The -.5 offset is an estimate to offset the center so that
-             *   it is visually balanced when showing the location on the map
-             *   on slightly righter side
-             **/
+            const zoomLevelOffset = zoomLevelFocusOffset[zoomLevel.focus] ?? 0;
             mapInstance.flyTo({
                 center: [
-                    locations[index].coord[0] - 0.5,
+                    locations[index].coord[0] - zoomLevelOffset,
                     locations[index].coord[1],
                 ],
-                zoom: LOCATION_FOCUS_ZOOM,
+                zoom: zoomLevel.focus,
                 duration: LOCATION_FOCUS_DURATION,
                 essential: true,
             });

--- a/app/data-access/trips.ts
+++ b/app/data-access/trips.ts
@@ -2,6 +2,7 @@ import type { DateFormat } from './date';
 
 export interface TripLocation {
     name: string;
+    nameId: string;
     description: string;
     coord: [lng: number, lat: number];
     date: { from: DateFormat; to?: DateFormat };
@@ -19,6 +20,10 @@ export interface TripDetails {
     map: Omit<maplibregl.MapOptions, 'style' | 'container'> & {
         pmtilesName: string;
         center: maplibregl.LngLatLike;
+        zoomLevel: {
+            init: number;
+            focus: number;
+        };
     };
     routeFileName: string;
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,6 +3,7 @@ import { index, route, type RouteConfig } from '@react-router/dev/routes';
 export default [
     index('./routes/index.tsx'),
     route('/trips/:tripId', './routes/trip-details-page.tsx'),
+    route('/location/:locationName', './routes/location-details-page.tsx'),
     route('/action/set-theme', './routes/actions/set-theme.ts'),
 
     route('*', './routes/_404.tsx'),

--- a/app/routes/location-details-page.tsx
+++ b/app/routes/location-details-page.tsx
@@ -20,9 +20,14 @@ export default function TripDetailsPage() {
     return (
         <div className="centered-max-width-1280">
             <h1
-                className='uppercase text-center text-6xl text-blue-500 font-bold'
-                style={{ height: `calc(100vh - ${FOOTER_HEIGHT}px)`, lineHeight: `calc(100vh - ${FOOTER_HEIGHT}px)` }}
-            >Under Construction</h1>
+                className="uppercase text-center text-6xl text-blue-500 font-bold"
+                style={{
+                    height: `calc(100vh - ${FOOTER_HEIGHT}px)`,
+                    lineHeight: `calc(100vh - ${FOOTER_HEIGHT}px)`,
+                }}
+            >
+                Under Construction
+            </h1>
         </div>
     );
 }

--- a/app/routes/location-details-page.tsx
+++ b/app/routes/location-details-page.tsx
@@ -1,0 +1,30 @@
+import { FOOTER_HEIGHT } from '~/containers/footer';
+import type { Route } from './+types/location-details-page';
+
+/**
+ *  TODO: we need to populate correct information on meta tag, checkout:
+ *      https://github.com/Alexius-Huang/travel.alexius-huang.dev/issues/44
+ */
+export function meta({ params }: Route.MetaArgs) {
+    return [
+        { title: `Travel | TO BE UPDATED` },
+        { name: 'description', content: `Details of "TO BE UPDATED"` },
+    ];
+}
+
+// export async function loader({ params }: Route.LoaderArgs) {
+//     return json<LoaderData>({ tripDetails, routeCoordinates });
+// }
+
+export default function TripDetailsPage() {
+    return (
+        <div className="centered-max-width-1280">
+            <h1
+                className='uppercase text-center text-6xl text-blue-500 font-bold'
+                style={{ height: `calc(100vh - ${FOOTER_HEIGHT}px)`, lineHeight: `calc(100vh - ${FOOTER_HEIGHT}px)` }}
+            >Under Construction</h1>
+        </div>
+    );
+}
+
+export { ErrorBoundary } from './index';

--- a/app/utils/trips.server.ts
+++ b/app/utils/trips.server.ts
@@ -1,29 +1,8 @@
 import type { TripDetails } from '~/data-access/trips';
 
-// TODO: move this to database and deprecate this page
-const locations: TripDetails['locations'] = [
-    {
-        name: 'New York City',
-        description:
-            "Home to legendary landmarks like the Statue of Liberty, the Empire State Building, and the 9/11 Memorial, this city is woven with history that helped shape the modern world. But it's not just about the past—its skyline is a masterpiece of modern ambition, glowing at sunset and sparkling after dark. From the cobblestone streets of Lower Manhattan to the soaring views from Top of the Rock, NYC is where history and innovation collide.",
-        coord: [-74.006, 40.7128],
-        date: { from: '2025-04-30', to: '2025-05-05' },
-    },
-    {
-        name: 'Philadelphia',
-        description:
-            "Walk the same streets where the Declaration of Independence was signed, stand beneath the Liberty Bell, and explore buildings that helped shape a nation. But beyond the founding chapters, Philly is a city with a chill soul—tree-lined neighborhoods, vibrant murals, cozy cafés, and a food scene that goes way beyond cheesesteaks. It's where past and present coexist effortlessly, making it the perfect place to learn, wander, and unwind.",
-        coord: [-75.1652, 39.9526],
-        date: { from: '2025-05-06', to: '2025-05-08' },
-    },
-    {
-        name: 'Washington D.C.',
-        description:
-            "As the political capital of the United States, it's home to the White House, the Capitol, and the Supreme Court—icons of democracy that shape the world. With the Smithsonian museums, stunning monuments, and cherry blossom-lined avenues, D.C. is a city that inspires both thought and awe. Whether you're walking the National Mall or discovering hidden gems in Georgetown, Washington D.C. is as enlightening as it is unforgettable.",
-        coord: [-77.0369, 38.9072],
-        date: { from: '2025-05-08', to: '2025-05-12' },
-    },
-];
+// TODO: Replace with actual data
+const LOREM_IPSUM =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
 
 export const TRIPS: Array<TripDetails> = [
     {
@@ -49,8 +28,37 @@ export const TRIPS: Array<TripDetails> = [
             maxBounds: [-78.898165, 37.787573, -71.3397, 41.610389],
             maxZoom: 10,
             center: [-75.60154093439161, 39.7254668759974],
+            zoomLevel: {
+                init: 7,
+                focus: 8,
+            },
         },
-        locations,
+        locations: [
+            {
+                name: 'New York City',
+                nameId: 'new-york-city',
+                description:
+                    "Home to legendary landmarks like the Statue of Liberty, the Empire State Building, and the 9/11 Memorial, this city is woven with history that helped shape the modern world. But it's not just about the past—its skyline is a masterpiece of modern ambition, glowing at sunset and sparkling after dark. From the cobblestone streets of Lower Manhattan to the soaring views from Top of the Rock, NYC is where history and innovation collide.",
+                coord: [-74.006, 40.7128],
+                date: { from: '2025-04-30', to: '2025-05-05' },
+            },
+            {
+                name: 'Philadelphia',
+                nameId: 'philadelphia',
+                description:
+                    "Walk the same streets where the Declaration of Independence was signed, stand beneath the Liberty Bell, and explore buildings that helped shape a nation. But beyond the founding chapters, Philly is a city with a chill soul—tree-lined neighborhoods, vibrant murals, cozy cafés, and a food scene that goes way beyond cheesesteaks. It's where past and present coexist effortlessly, making it the perfect place to learn, wander, and unwind.",
+                coord: [-75.1652, 39.9526],
+                date: { from: '2025-05-06', to: '2025-05-08' },
+            },
+            {
+                name: 'Washington D.C.',
+                nameId: 'washington-dc',
+                description:
+                    "As the political capital of the United States, it's home to the White House, the Capitol, and the Supreme Court—icons of democracy that shape the world. With the Smithsonian museums, stunning monuments, and cherry blossom-lined avenues, D.C. is a city that inspires both thought and awe. Whether you're walking the National Mall or discovering hidden gems in Georgetown, Washington D.C. is as enlightening as it is unforgettable.",
+                coord: [-77.0369, 38.9072],
+                date: { from: '2025-05-08', to: '2025-05-12' },
+            },
+        ],
         routeFileName: '2025-05-us',
     },
     {
@@ -66,13 +74,39 @@ export const TRIPS: Array<TripDetails> = [
 
         // TODO: replcae this to germany map
         map: {
-            pmtilesName: '2025-05-us.v2',
-            maxBounds: [-78.898165, 37.787573, -71.3397, 41.610389],
-            maxZoom: 10,
-            center: [-75.60154093439161, 39.7254668759974],
+            pmtilesName: '2025-04-de',
+            maxBounds: [9.486131, 51.7356, 11.528907, 52.712054],
+            maxZoom: 11,
+            center: [10.523213, 52.264457],
+            zoomLevel: {
+                init: 10,
+                focus: 11,
+            },
         },
-        locations,
-        routeFileName: '2025-05-us',
+        locations: [
+            {
+                name: 'Braunschweig',
+                nameId: 'braunschweig',
+                description: LOREM_IPSUM,
+                coord: [10.516667, 52.266666],
+                date: { from: '2025-04-18' },
+            },
+            {
+                name: 'Wolfsburg',
+                nameId: 'wolfsburg',
+                description: LOREM_IPSUM,
+                coord: [10.7865, 52.4227],
+                date: { from: '2025-04-19' },
+            },
+            {
+                name: 'Wolfenbüttel',
+                nameId: 'wolfenbuettel',
+                description: LOREM_IPSUM,
+                coord: [10.5342, 52.1604],
+                date: { from: '2025-04-20' },
+            },
+        ],
+        routeFileName: '2025-04-de',
     },
     {
         id: 3,
@@ -87,12 +121,31 @@ export const TRIPS: Array<TripDetails> = [
 
         // TODO: replcae this to italy map
         map: {
-            pmtilesName: '2025-05-us.v2',
-            maxBounds: [-78.898165, 37.787573, -71.3397, 41.610389],
-            maxZoom: 10,
-            center: [-75.60154093439161, 39.7254668759974],
+            pmtilesName: '2024-11-it',
+            maxBounds: [9.619174, 43.274784, 11.967384, 44.256538],
+            maxZoom: 12,
+            center: [10.85991, 43.720627],
+            zoomLevel: {
+                init: 9,
+                focus: 11,
+            },
         },
-        locations,
-        routeFileName: '2025-05-us',
+        locations: [
+            {
+                name: 'Pisa',
+                nameId: 'pisa',
+                description: LOREM_IPSUM,
+                coord: [10.4018, 43.7228],
+                date: { from: '2024-11-29', to: '2024-11-30' },
+            },
+            {
+                name: 'Firenze',
+                nameId: 'firenze',
+                description: LOREM_IPSUM,
+                coord: [11.2577, 43.77],
+                date: { from: '2024-11-30', to: '2024-12-01' },
+            },
+        ],
+        routeFileName: '2024-11-it.v2',
     },
 ];

--- a/bin/generate-map.js
+++ b/bin/generate-map.js
@@ -87,6 +87,10 @@ const month = String(today.getMonth() + 1).padStart(2, '0');
 const day = String(today.getDate()).padStart(2, '0');
 const dateString = `${year}${month}${day}`;
 
+/**
+ *  TODO: If the request failed, it might be due to the archive for the map
+ *        is not geneerated on that day
+ */
 const pmtilesUrl = `https://build.protomaps.com/${dateString}.pmtiles`;
 const outputFile = `${pmtilesName}.pmtiles`;
 


### PR DESCRIPTION
## Description

This pull targets the issue: #33 where it creates LDP and navigate to it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Other: ______

## How Has This Been Tested?

- [x] Created production build and tested locally
- [ ] Other: ______

## Solution

- [x] Create `/location/{nameId}` route with the page `location-details-page`
- [x] Link the home page's timeline section -- location-carousel to LDP
- [x] Link the "View Details" button from TDP route map's location details to LDP
- [x] Allow map pin in TDP route map to first quick scroll to route map corresponding location (if not focused), then navigate to LDP on 2nd click

## Screenshots

Navigation from Home page's location carousel:

https://github.com/user-attachments/assets/cd7c3dcb-d4fc-4d6b-bee0-d4acfbb79ccf

Navigation from TDP's View Details button:

https://github.com/user-attachments/assets/3fde86bf-2dca-4e2c-bfdd-8a678fa143c3

Map Pin interaction on TDP:

https://github.com/user-attachments/assets/e46c3ff8-21c1-4885-a331-9d8b3062dab7
